### PR TITLE
Fixed LCP Bundler

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,7 +19,7 @@ jobs:
               run: pwd
             - name: bump the lcp_manifest version
               run:  
-                cp lcp_manifest.json.tmp
+                cp lcp_manifest.json lcp_manifest.json.tmp
                 cat lcp_manifest.json
                 jq '.version |= ${{ github.event.release.tag_name }}' > lcp_manifest.json
                 rm lcp_manifest.json.tmp

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,9 +10,9 @@ permissions:
 jobs:
     bundle-lcp:
         runs-on: ubuntu-latest
-        defaults:
-            run:
-                working-directory: NPC\ Rebakes
+        # defaults:
+        #     run:
+        #         working-directory: NPC\ Rebakes
         steps:
             - name: ls cwd
               run: ls

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,8 +14,8 @@ jobs:
         #     run:
         #         working-directory: NPC\ Rebakes
         steps:
-            - name: ls cwd
-              run: ls
+            - name: pwd
+              run: pwd
             - name: bump the lcp_manifest version
               run:  |
                 lcp_manifest.json

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,6 +19,7 @@ jobs:
               run: pwd
             - name: bump the lcp_manifest version
               run:  
+                touch lcp_manifest.json.tmp
                 cp lcp_manifest.json lcp_manifest.json.tmp
                 cat lcp_manifest.json
                 jq '.version |= ${{ github.event.release.tag_name }}' > lcp_manifest.json

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,7 +2,7 @@ name: LCP bundler
 
 on: 
     release:
-        types: [created, published]
+        types: [published]
 
 permissions:
     contents: write

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,6 +14,7 @@ jobs:
             run:
                 working-directory: 'NPC Rebakes'
         steps:
+            - uses: actions/checkout@v4
             - name: pwd
               run: pwd
             - name: bump the lcp_manifest version

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,16 +10,18 @@ permissions:
 jobs:
     bundle-lcp:
         runs-on: ubuntu-latest
-        # defaults:
-        #     run:
-        #         working-directory: NPC\ Rebakes
+        defaults:
+            run:
+                working-directory: 'NPC Rebakes'
         steps:
             - name: pwd
               run: pwd
             - name: bump the lcp_manifest version
-              run:  |
-                lcp_manifest.json
-                jq '.version |= ${{ github.event.release.tag_name }}'
+              run:  
+                cp lcp_manifest.json.tmp
+                cat lcp_manifest.json
+                jq '.version |= ${{ github.event.release.tag_name }}' > lcp_manifest.json
+                rm lcp_manifest.json.tmp
             - name: zip up the LCP
               run: |
                 zip -r "kais-npc-rebakes-${{ github.event.release.tag_name }}.lcp" *.json


### PR DESCRIPTION
- Fixed `working-directory`
- created tmp files to process the version bump with `jq` properly
- changed `on.release.types` to run only on `published` events