### PR TITLE
[Fix] Use temp file correctly when bumping manifest version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,15 +15,13 @@ jobs:
                 working-directory: 'NPC Rebakes'
         steps:
             - uses: actions/checkout@v4
-            - name: pwd
-              run: pwd
             - name: bump the lcp_manifest version
               run:  
-                touch lcp_manifest.json.tmp
-                cp lcp_manifest.json lcp_manifest.json.tmp
-                cat lcp_manifest.json
+                touch lcp_manifest.tmp.json
+                cp lcp_manifest.json lcp_manifest.tmp.json
+                cat lcp_manifest.tmp.json
                 jq '.version |= ${{ github.event.release.tag_name }}' > lcp_manifest.json
-                rm lcp_manifest.json.tmp
+                rm lcp_manifest.tmp.json
             - name: zip up the LCP
               run: |
                 zip -r "kais-npc-rebakes-${{ github.event.release.tag_name }}.lcp" *.json


### PR DESCRIPTION
Was not using the temp file at all and caused the `lcp_manifest` to generate a blank file