### PR TITLE
Properly pipe contents of `lcp_manifest.tmp.json` into `jq`

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,7 +19,7 @@ jobs:
               env:
                 MANIFEST_VERSION: ${{ github.event.release.tag_name }}
               run:  
-                contents="$(jq --arg version "$MANIFEST_VERSION" '.version |= $version')"
+                contents="$(jq --arg version "$MANIFEST_VERSION" '.version |= $version' lcp_manifest.json)"
                 echo -E "${contents}" > lcp_manifest.json
             - name: zip up the LCP
               run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,8 +19,7 @@ jobs:
               run:  
                 touch lcp_manifest.tmp.json
                 cp lcp_manifest.json lcp_manifest.tmp.json
-                cat lcp_manifest.tmp.json
-                jq '.version |= ${{ github.event.release.tag_name }}' > lcp_manifest.json
+                cat lcp_manifest.tmp.json | jq '.version |= ${{ github.event.release.tag_name }}' > lcp_manifest.json
                 rm lcp_manifest.tmp.json
             - name: zip up the LCP
               run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,6 @@ jobs:
                 MANIFEST_VERSION: ${{ github.event.release.tag_name }}
               run: |
                 contents="$(jq --arg version "$MANIFEST_VERSION" '.version |= $version' lcp_manifest.json)"
-                echo -E "${contents}" >> $GITHUB_OUTPUT
                 echo -E "${contents}" > lcp_manifest.json
             - name: zip up the LCP
               run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
             - name: bump the lcp_manifest version
               env:
                 MANIFEST_VERSION: ${{ github.event.release.tag_name }}
-              run:  
+              run: |
                 contents="$(jq --arg version "$MANIFEST_VERSION" '.version |= $version' lcp_manifest.json)"
                 echo -E "${contents}" >> $GITHUB_OUTPUT
                 echo -E "${contents}" > lcp_manifest.json

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,6 +20,7 @@ jobs:
                 MANIFEST_VERSION: ${{ github.event.release.tag_name }}
               run:  
                 contents="$(jq --arg version "$MANIFEST_VERSION" '.version |= $version' lcp_manifest.json)"
+                echo -E "${contents}"
                 echo -E "${contents}" > lcp_manifest.json
             - name: zip up the LCP
               run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,11 +16,11 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - name: bump the lcp_manifest version
+              env:
+                MANIFEST_VERSION: ${{ github.event.release.tag_name }}
               run:  
-                touch lcp_manifest.tmp.json
-                cp lcp_manifest.json lcp_manifest.tmp.json
-                cat lcp_manifest.tmp.json | jq '.version |= ${{ github.event.release.tag_name }}' > lcp_manifest.json
-                rm lcp_manifest.tmp.json
+                contents="$(jq --arg version "$MANIFEST_VERSION" '.version |= $version')"
+                echo -E "${contents}" > lcp_manifest.json
             - name: zip up the LCP
               run: |
                 zip -r "kais-npc-rebakes-${{ github.event.release.tag_name }}.lcp" *.json

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,7 +20,7 @@ jobs:
                 MANIFEST_VERSION: ${{ github.event.release.tag_name }}
               run:  
                 contents="$(jq --arg version "$MANIFEST_VERSION" '.version |= $version' lcp_manifest.json)"
-                echo -E "${contents}"
+                echo -E "${contents}" >> $GITHUB_OUTPUT
                 echo -E "${contents}" > lcp_manifest.json
             - name: zip up the LCP
               run: |


### PR DESCRIPTION
the `cat` command was not piping into anything, so the input of `jq` was nothing at all.