### PR TITLE
Decapitalize NPC Class Names + Feature Names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Base NPCs
+/node_modules

--- a/Grunt Rebake Pack/npc_classes.json
+++ b/Grunt Rebake Pack/npc_classes.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "grunt-rebake_gruntc_artillery",
-        "name": "ARTILLERY GRUNT",
+        "name": "Artillery Grunt",
         "role": "artillery",
         "info": {
             "flavor": "",
@@ -98,7 +98,7 @@
     },
     {
         "id": "grunt-rebake_gruntc_controller",
-        "name": "CONTROLLER GRUNT",
+        "name": "Controller Grunt",
         "role": "controller",
         "info": {
             "flavor": "",
@@ -183,16 +183,16 @@
             ]
         },
         "base_features": [
-            "npcf_flamethrower_pyro",
+            "npcf_flamethrower_pyro"
         ],
         "optional_features": [
-            "npcf_unshielded_reactor_pyro",
+            "npcf_unshielded_reactor_pyro"
         ],
         "power": 100
     },
     {
         "id": "grunt-rebake_gruntc_defender",
-        "name": "DEFENDER GRUNT",
+        "name": "Defender Grunt",
         "role": "defender",
         "info": {
             "flavor": "",
@@ -277,16 +277,16 @@
             ]
         },
         "base_features": [
-            "npcf_flamethrower_pyro",
+            "npcf_flamethrower_pyro"
         ],
         "optional_features": [
-            "npcf_unshielded_reactor_pyro",
+            "npcf_unshielded_reactor_pyro"
         ],
         "power": 100
     },
     {
         "id": "grunt-rebake_gruntc_striker",
-        "name": "STRIKER GRUNT",
+        "name": "Striker Grunt",
         "role": "striker",
         "info": {
             "flavor": "",
@@ -371,16 +371,16 @@
             ]
         },
         "base_features": [
-            "npcf_flamethrower_pyro",
+            "npcf_flamethrower_pyro"
         ],
         "optional_features": [
-            "npcf_unshielded_reactor_pyro",
+            "npcf_unshielded_reactor_pyro"
         ],
         "power": 100
     },
     {
         "id": "grunt-rebake_gruntc_support",
-        "name": "SUPPORT GRUNT",
+        "name": "Support Grunt",
         "role": "support",
         "info": {
             "flavor": "",
@@ -465,11 +465,11 @@
             ]
         },
         "base_features": [
-            "npcf_flamethrower_pyro",
+            "npcf_flamethrower_pyro"
         ],
         "optional_features": [
-            "npcf_unshielded_reactor_pyro",
+            "npcf_unshielded_reactor_pyro"
         ],
         "power": 100
-    },
+    }
 ]

--- a/Grunt Rebake Pack/npc_features.json
+++ b/Grunt Rebake Pack/npc_features.json
@@ -55,7 +55,7 @@
     },
     {
         "id": "grunt-rebake_gruntf_shoulder_mortar_artillery",
-        "name": "Shouler Mortar",
+        "name": "Shoulder Mortar",
         "origin": {
             "type": "Class",
             "name": "Artillery Grunt",

--- a/Grunt Rebake Pack/npc_features.json
+++ b/Grunt Rebake Pack/npc_features.json
@@ -1,10 +1,10 @@
 [
     {
         "id": "grunt-rebake_gruntf_artillery_type_artillery",
-        "name": "ARTILLERY TYPE",
+        "name": "Artillery Type",
         "origin": {
             "type": "Class",
-            "name": "ARTILLERY GRUNT",
+            "name": "Artillery Grunt",
             "base": true
         },
         "locked": false,
@@ -17,7 +17,7 @@
         "name": "DMR",
         "origin": {
             "type": "Class",
-            "name": "ARTILLERY GRUNT",
+            "name": "Artillery Grunt",
             "base": false
         },
         "locked": false,
@@ -55,10 +55,10 @@
     },
     {
         "id": "grunt-rebake_gruntf_shoulder_mortar_artillery",
-        "name": "SHOULER MORTAR",
+        "name": "Shouler Mortar",
         "origin": {
             "type": "Class",
-            "name": "ARTILLERY GRUNT",
+            "name": "Artillery Grunt",
             "base": false
         },
         "locked": false,
@@ -105,10 +105,10 @@
     },
     {
         "id": "grunt-rebake_gruntf_survival_pistol_artillery",
-        "name": "SURVIVAL PISTOL",
+        "name": "Survival Pistol",
         "origin": {
             "type": "Class",
-            "name": "ARTILLERY GRUNT",
+            "name": "Artillery Grunt",
             "base": true
         },
         "locked": false,
@@ -152,15 +152,15 @@
     },
     {
         "id": "grunt-rebake_gruntf_reflex_targeting_artillery",
-        "name": "REFLEX TARGETING",
+        "name": "Reflex Targeting",
         "origin": {
             "type": "Class",
-            "name": "ARTILLERY GRUNT",
+            "name": "Artillery Grunt",
             "base": true
         },
         "locked": false,
         "type": "Trait",
         "effect": "The Artillery-Type has +5 Sensors, and may take the Lock On and Search actions before attacking with Ordnance weapons.",
         "tags": []
-    },
+    }
 ]

--- a/NPC Rebakes/npc_classes.json
+++ b/NPC Rebakes/npc_classes.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "npc-rebake_npcc_assault",
-        "name": "ASSAULT [K]",
+        "name": "Assault [K]",
         "info": {
             "flavor": "Assault mechs are the most common primary battle frames found throughout the galaxy. Fitted with a heavy rifle, a sidearm, and a suite of systems that enhance movement, targeting, and defensibility, they are straightforward, reliable, and hardy combatants. The pilots of Assault mechs are also the cheapest to train and outfit, but that doesn’t make them any less dangerous.",
             "tactics": "The Assault is a straightforward, damage-dealing striker that emphasizes the importance of taking cover. Equipped to do good damage at decent range, they want to flank their opponents or drive them out of cover in order to maximize their effectiveness. <strong>Hunker Down</strong> can increase their survivability, but leaves them less able to maneuver in return."
@@ -103,7 +103,7 @@
     },
     {
         "id": "npc-rebake_npcc_aegis",
-        "name": "AEGIS [K]",
+        "name": "Aegis [K]",
         "info": {
             "flavor": "",
             "tactics": "Aegises are tough and defensive support units. They are most effective when positioned so that their Defense Net can cover as many allies as possible, as the Aegis itself is slow-moving and can't reposition quickly. They can also protect their allies from the effects of Impaired and Slowed while being immune to those conditions themselves."
@@ -205,7 +205,7 @@
     },
     {
         "id": "npc-rebake_npcc_ace",
-        "name": "ACE [K]",
+        "name": "Ace [K]",
         "role": "striker",
         "info": {
             "flavor": "The first person to embody the “Ace” archetype was Aisling Jensen, an auxiliary pilot active during the liberation of Verdana. Knights of the chassis and sky, Aces like Aisling throw their mechs into battle with high-speed strafing runs, agile maneuvers, and reckless feats of daring. Cocky and self-assured, Aces relish a good duel.",
@@ -305,7 +305,7 @@
     },
     {
         "id": "npc-rebake_npcc_archer",
-        "name": "ARCHER [K]",
+        "name": "Archer [K]",
         "role": "controller",
         "info": {
             "flavor": "The basis of the Archer archetype, Ursa Major’s Gatekeeper Key-II, was popularized by Ichabod Carden’s heroic actions in the Battle of Terramoto. Archer-archetype mechs sacrifice armor for powerful targeting and superpositional maneuvering systems, making them especially popular with pilots who prefer to have control over the precise destination of each shot.",
@@ -406,7 +406,7 @@
     },
     {
         "id": "npc-rebake_npcc_assassin",
-        "name": "ASSASSIN [K]",
+        "name": "Assassin [K]",
         "role": "striker",
         "info": {
             "flavor": "Assassins tend towards agility, damage, and speed. These pilots sacrifice comfort for efficiency, stripping out everything from life-support to comms systems and replacing them with increased processing power and stealth capabilities. Assassins work alone or in small groups, piloting their small, sleek mechs through near-impenetrable terrain to catch their targets off-guard.",
@@ -510,7 +510,7 @@
     },
     {
         "id": "npc-rebake_npcc_barricade",
-        "name": "BARRICADE [K]",
+        "name": "Barricade [K]",
         "role": "controller",
         "info": {
             "flavor": "Veld Systems’ Keeper Pattern 5 is a common guard mech made famous after the platform’s performance during the Battle of Sing Rama Sing. During the battle, Audrey Reimaus of the Seraphs’ Company used a Keeper P5 to singlehandedly secure Rama City’s main uplift tower, thus guaranteeing an evacuation corridor for the city’s civilian population.",
@@ -612,7 +612,7 @@
     },
     {
         "id": "npc-rebake_npcc_bastion",
-        "name": "BASTION [K]",
+        "name": "Bastion [K]",
         "role": "defender",
         "info": {
             "flavor": "Bastions trade the pure defensive edge of Aegis-archetype mechs for greater mobility. They blend area-denial offensive capabilities with hardened defense systems and advanced communication suites. These mechs are favorites of many strong squadron commanders. The efficacy of the pairing was best displayed by the actions of Zander Reeves, a field-promoted auxiliary officer, during engagements with the “Space Between” interstellar pirate guild in the Dromeda system.",
@@ -713,7 +713,7 @@
     },
     {
         "id": "npc-rebake_npcc_berserker",
-        "name": "BERSERKER [K]",
+        "name": "Berserker [K]",
         "role": "striker",
         "info": {
             "flavor": "Berserker mechs are built to take advantage of advanced heat-cycling systems that allow them to shunt heat - as it is generated - into pure offensive force, increasing their weapon output by orders of magnitude. The archetype, best-known for its use by Gen’Dal Merlos’s Knights of Imminent Destruction, is preferred by pure combat-focus organizations, PMCs, and deniable-asset corps in established states.",
@@ -814,7 +814,7 @@
     },
     {
         "id": "npc-rebake_npcc_bombard",
-        "name": "BOMBARD [K]",
+        "name": "Bombard [K]",
         "role": "artillery",
         "info": {
             "flavor": "Alta All-Theater Ballistics’ archetypal Bombard chassis and their licensed facsimiles are a common sight in flashpoints across the galaxy. Built for staying power across long-uptime deployments, Bombard-type mechs are an accessible solution for armed forces looking to quickly deploy artillery to a theater. Chassis configured to the parameters of this class are usually positioned in fortified positions miles behind the line; one especially asymmetrical deployment strategy involves placing Bombard batteries above the theater of operations – typically on a local moon, locked-orbit natural satellite, or on a purpose-built orbital platform. From their vantage point, the battery can then rain shells down upon the world below, far removed from the dangers of combat.",
@@ -915,7 +915,7 @@
     },
     {
         "id": "npc-rebake_npcc_breacher",
-        "name": "BREACHER [K]",
+        "name": "Breacher [K]",
         "role": "striker",
         "info": {
             "flavor": "Notoriously effective in boarding operations, the Campbell Orbital Dynamics C-O MkIII is often seen in the arsenals of suborbital planetary defense forces and their pirate counterparts. Officially, the CO designation is an abbreviation of “CombatOrbital”, but unofficially, the CO3 goes by a different name: the “Can Opener”, inspired by the callsign of Valeria Rojas-Sarnik, one of the most storied CO3 pilots.",
@@ -1016,7 +1016,7 @@
     },
     {
         "id": "npc-rebake_npcc_cataphract",
-        "name": "CATAPHRACT [K]",
+        "name": "Cataphract [K]",
         "role": "striker",
         "info": {
             "flavor": "Cataphract squadrons are made up of rapid-strike mechs that emphasize mobility, shock, and tenacity; it follows, then, that Cataphract archetypes are feared across the galaxy for their ability to overwhelm defenses in moments. There are few things more terrifying (or inspiring) than a squadron of Cataphracts punching through a static battle line, heavy cannons and point-defense weapons wiping out previously immovable defenders. The flagship Cataphract-class chassis is the Sine Die Systems END-44, an angular beast of a mech outfitted with SDS’s fearsome Ram Cannon. The enduring popularity of the chassis can be attributed to the success of Catherine “C-80” Need, who made their name piloting an END-44 to victory in the defense of Carina-Proximal.",
@@ -1117,7 +1117,7 @@
     },
     {
         "id": "npc-rebake_npcc_demolisher",
-        "name": "DEMOLISHER [K]",
+        "name": "Demolisher [K]",
         "role": "defender",
         "info": {
             "flavor": "The lengthy siege of Jadigmora City saw the development of the first true Demolisher frames. Based on antique Berserker mechs, Demolishers swapped dramatic heat flows for more sustainable systems, improved hydraulic strength, and stabilizers for supermassive melee weapons. Demolisher pilots soon discovered a range of new applications for their concussion-wave ordnance. A lancer named Hayes Rothford and their NHP, Clarke, were the first pilot/co-pilot team to truly show the power of the platform, singlehandedly bringing down a siege frigate in low orbit.",
@@ -1218,108 +1218,108 @@
     },
     {
         "id": "npc-rebake_npcc_engineer",
-        "name": "ENGINEER [K]",
+        "name": "Engineer [K]",
         "role": "striker",
         "info": {
-          "flavor": "Various types of localized Engineer-class mechs are common throughout the galaxy, unique to the worlds or theaters in which they operate. The Engineer has long existed as an archetype, but it remained largely undefined until a full design doctrine was laid out by Corrida Isolde-Nollet, an Armory civil service director on Ras Shamra. In all cases, the mission of Engineers is the same: defend, maintain, secure. Engineers operate best in the middle or rear of the battle line, coordinating the defense of important positions and overseeing comprehensive deployment of all operational assets. Remember: if you can’t get to the enemy, you lose.",
-          "tactics": "Engineers’ <strong>Deployable Turrets</strong> make them potent force multipliers, as they can continue to deploy new ones each turn. If enemies don’t deal with an Engineer's turrets, their potential damage and battefield utility quickly skyrockets. <strong>Target Designator</strong> can be used to focus fire upon selected foes, as otherwise turrets attack the nearest target, which players can use to control who takes damage."
+            "flavor": "Various types of localized Engineer-class mechs are common throughout the galaxy, unique to the worlds or theaters in which they operate. The Engineer has long existed as an archetype, but it remained largely undefined until a full design doctrine was laid out by Corrida Isolde-Nollet, an Armory civil service director on Ras Shamra. In all cases, the mission of Engineers is the same: defend, maintain, secure. Engineers operate best in the middle or rear of the battle line, coordinating the defense of important positions and overseeing comprehensive deployment of all operational assets. Remember: if you can’t get to the enemy, you lose.",
+            "tactics": "Engineers’ <strong>Deployable Turrets</strong> make them potent force multipliers, as they can continue to deploy new ones each turn. If enemies don’t deal with an Engineer's turrets, their potential damage and battefield utility quickly skyrockets. <strong>Target Designator</strong> can be used to focus fire upon selected foes, as otherwise turrets attack the nearest target, which players can use to control who takes damage."
         },
         "stats": {
-          "armor": [
-            0,
-            0,
-            0
-          ],
-          "hp": [
-            20,
-            22,
-            24
-          ],
-          "evade": [
-            7,
-            8,
-            9
-          ],
-          "edef": [
-            10,
-            12,
-            14
-          ],
-          "heatcap": [
-            10,
-            10,
-            10
-          ],
-          "speed": [
-            3,
-            3,
-            3
-          ],
-          "sensor": [
-            15,
-            15,
-            15
-          ],
-          "save": [
-            10,
-            12,
-            14
-          ],
-          "hull": [
-            -1,
-            -1,
-            -1
-          ],
-          "agility": [
-            -1,
-            -1,
-            -1
-          ],
-          "systems": [
-            1,
-            2,
-            3
-          ],
-          "engineering": [
-            3,
-            4,
-            5
-          ],
-          "size": [
-            [
-              1
+            "armor": [
+                0,
+                0,
+                0
             ],
-            [
-              1
+            "hp": [
+                20,
+                22,
+                24
             ],
-            [
-              1
+            "evade": [
+                7,
+                8,
+                9
+            ],
+            "edef": [
+                10,
+                12,
+                14
+            ],
+            "heatcap": [
+                10,
+                10,
+                10
+            ],
+            "speed": [
+                3,
+                3,
+                3
+            ],
+            "sensor": [
+                15,
+                15,
+                15
+            ],
+            "save": [
+                10,
+                12,
+                14
+            ],
+            "hull": [
+                -1,
+                -1,
+                -1
+            ],
+            "agility": [
+                -1,
+                -1,
+                -1
+            ],
+            "systems": [
+                1,
+                2,
+                3
+            ],
+            "engineering": [
+                3,
+                4,
+                5
+            ],
+            "size": [
+                [
+                    1
+                ],
+                [
+                    1
+                ],
+                [
+                    1
+                ]
+            ],
+            "activations": [
+                1,
+                1,
+                1
             ]
-          ],
-          "activations": [
-            1,
-            1,
-            1
-          ]
         },
         "base_features": [
-          "npc-rebake_npcf_flak_cannon_engineer",
-          "npc-rebake_npcf_deployable_turret_engineer",
-          "npc-rebake_npcf_target_designator_engineer"
+            "npc-rebake_npcf_flak_cannon_engineer",
+            "npc-rebake_npcf_deployable_turret_engineer",
+            "npc-rebake_npcf_target_designator_engineer"
         ],
         "optional_features": [
-          "npc-rebake_npcf_deployable_fortifications_engineer",
-          "npc-rebake_npcf_perimeter_defense_engineer",
-          "npc-rebake_npcf_auto_tracking_engineer",
-          "npc-rebake_npcf_mobile_turrets_engineer",
-          "npc-rebake_npcf_skyshield_protocol_engineer",
-          "npc-rebake_npcf_repurpose_engineer"
+            "npc-rebake_npcf_deployable_fortifications_engineer",
+            "npc-rebake_npcf_perimeter_defense_engineer",
+            "npc-rebake_npcf_auto_tracking_engineer",
+            "npc-rebake_npcf_mobile_turrets_engineer",
+            "npc-rebake_npcf_skyshield_protocol_engineer",
+            "npc-rebake_npcf_repurpose_engineer"
         ],
         "power": 100
-      },
+    },
     {
         "id": "npc-rebake_npcc_goliath",
-        "name": "GOLIATH [K]",
+        "name": "Goliath [K]",
         "role": "defender",
         "info": {
             "flavor": "Along the Sierra Madre Line – the eighth ring of territory out from Cradle – the Dangun frame is a familiar sight. Manufactured by Park Armored Systems and popularized by the Dagger Squadron mercenary company, the Dangun is popular for its toughness, kinetic damage-trade ability, and reliable all-theater performance. The Dangun is a mech to build strike forces around – a Goliath-class frame capable of mounting powerful magtech, with a design that’s tough to counter in kinetic damage combat.<br>With a number of small fleet contracts in its portfolio, Park Armored Systems is a manufacturer worth keeping an eye on; indeed, Harrison Armory has taken particular notice, and omninet rumors suggest a possible partnership in the near future.",
@@ -1421,7 +1421,7 @@
     },
     {
         "id": "npc-rebake_npcc_hive",
-        "name": "HIVE [K]",
+        "name": "Hive [K]",
         "role": "controller",
         "info": {
             "flavor": "In theory, drones and drone swarms developed after the Deimos Event are not too different from their older cousins: they establish a local omninetwork; fabricate and deploy a century or half-century of drones; and then coordinate them to achieve their objectives. Still, the complex handler–trainer relationships that allow pilots to segue between direct control and autonomous operation cause psychological trauma after a month of continuous drone operation. It is recommended that they cycle their paired hive nexus every two weeks.",
@@ -1521,7 +1521,7 @@
     },
     {
         "id": "npc-rebake_npcc_hornet",
-        "name": "HORNET [K]",
+        "name": "Hornet [K]",
         "role": "controller",
         "info": {
             "flavor": "SatriaBarong’s Espada range of half-frame mechs has long been a popular choice in the chassis racing circuit; notably, Espadas are the mechs of choice for the vaunted SatriaBarong–ShimanoLUX chassis racing team. Recently, SatriaBarong – with the blessing of SSC – has moved to create a mil-spec, de-licensed variant of the Espada without the ShimanoLUX branding, giving rise to the Hornet archetype, a platform open for other companies to adapt and improve. The most notable of these competitors is Chandrasekhar & Herschel, the primary sponsor of the new Blueshift Grand Prix racing circuit.",
@@ -1622,7 +1622,7 @@
     },
     {
         "id": "npc-rebake_npcc_operator",
-        "name": "OPERATOR [K]",
+        "name": "Operator [K]",
         "role": "artillery",
         "info": {
             "flavor": "Operators are known-unknowns, rarely encountered on the front lines, but this should not be mistaken for fragility. Operators are dangerous and deadly in every way. Like their mechs, Operators’ bodies are loaded with the most advanced tech available. When they die in combat, it’s not unknown for their bodies – and their mechs — to self-immolate, rendering any technology and data into ash.",
@@ -1723,7 +1723,7 @@
     },
     {
         "id": "npc-rebake_npcc_pyro",
-        "name": "PYRO [K]",
+        "name": "Pyro [K]",
         "role": "defender",
         "info": {
             "flavor": "First popularized in the wake of the Hercynian Crisis by the lancer Flama and their aptly named Devil Corps, Pyro frames are reviled across the galaxy as the embodiment of the pure destructive power held by militarized states and corpro-states. Their use is common within organizations for which the ends justify the means. Pyros are well-armored, and better insulated than most chassis of similar gross weight, designed to manage incredible internal heat while projecting volatile mixes of chemicals and flame toward their enemies. Pyros are often used in urban and jungle warfare, where they can be used to root out entrenched defenders.",
@@ -1824,7 +1824,7 @@
     },
     {
         "id": "npc-rebake_npcc_ronin",
-        "name": "RONIN [K]",
+        "name": "Ronin [K]",
         "role": "striker",
         "info": {
             "flavor": "Ronin frames differ from those favored by Berserkers and Demolishers in that they aren’t retrofitted or improvised for creative tactical applications – they are purpose-built to excel in melee combat by boutique fabricators. Although they are seen as somewhat antique by many commentators, the rise of stasis- and mag-based defensive technologies has made Ronins more viable in modern combat.<br>Ronin are common among both martial cultures and performance-combat firms, where their superb melee abilities elevate them above the competition. They see less use in cultures that have a preference for ranged combat, but there is a certain prestige accorded to pilots who adopt ancient weapons and survive to do it again. The mythic lancer Susanoo elevated this archetype to legendary status when she endorsed the GRAMtech Strike-1 chassis, which she piloted alongside numerous Albatross wings during the Neo-Celestine Disappointment.",
@@ -1924,7 +1924,7 @@
     },
     {
         "id": "npc-rebake_npcc_scourer",
-        "name": "SCOURER [K]",
+        "name": "Scourer [K]",
         "role": "striker",
         "info": {
             "flavor": "Scourer-class mechs are distinctive for carrying deadly Energy damage weapons powered by massive-output recursive power plants. These mechs are found across the galaxy in specialist roles, supporting conventional ground troops with powerful beam attacks that stop electronic threats as easily as they stop enemy soldiers.",
@@ -2025,7 +2025,7 @@
     },
     {
         "id": "npc-rebake_npcc_scout",
-        "name": "SCOUT [K]",
+        "name": "Scout [K]",
         "role": "support",
         "info": {
             "flavor": "The most devastating mechanized-warfare strategies call for the active, close, and aggressive application of orbital, atmospheric, and terrestrial fire-support. Enter Scout-class mechs and their pilots. Using advanced targeting systems, Scouts are equal parts tactical coordinator and artillery commander, working with allies to map the battlescape and accurately place direct-targeted and autonomous fire.",
@@ -2129,7 +2129,7 @@
     },
     {
         "id": "npc-rebake_npcc_seeder",
-        "name": "SEEDER [K]",
+        "name": "Seeder [K]",
         "role": "controller",
         "info": {
             "flavor": "Seeder-archetype mechs are sappers, adept at deploying defensive nets of mines and traps. Laden with ordnance and bristling with sensor suites, Seeders operate in small teams: together, they blanket battlefields in traps and pitfalls, planting mines and other area-denial systems to guide the enemy into kill-boxes.",
@@ -2229,7 +2229,7 @@
     },
     {
         "id": "npc-rebake_npcc_sentinel",
-        "name": "SENTINEL [K]",
+        "name": "Sentinel [K]",
         "role": "defender",
         "info": {
             "flavor": "Sentinel archetypes are typically employed as guards and escorts, often in the retinues of commanders or posted in defense of artillery. These mechs and their pilots employ advanced suites of technology to ensure their wards stay alive and operational, even if that costs their own chassis – or lives. Unlike the heavier Bastion archetypes, Sentinels are quick and light: they practice active defense, preemptively striking with suites of advanced technical, systemic, and direct weaponry to protect their charges.",
@@ -2331,7 +2331,7 @@
     },
     {
         "id": "npc-rebake_npcc_sniper",
-        "name": "SNIPER [K]",
+        "name": "Sniper [K]",
         "role": "artillery",
         "info": {
             "flavor": "The reason some pilots haven’t seen a Sniper on the battlefield is that those pilots are dead. These mechs are built for stability, targeting, and extremely long-range  kinetic damage weapons at the cost of mobility, and they tend to operate in small, self-sufficient teams far removed from direct combat. Sniper pilots are a proud breed, emphasizing economy and elegance over destructive power.",
@@ -2432,7 +2432,7 @@
     },
     {
         "id": "npc-rebake_npcc_specter",
-        "name": "SPECTER [K]",
+        "name": "Specter [K]",
         "role": "striker",
         "info": {
             "flavor": "The principle behind the development of Specter-archetype mechs is a simple one: not being hit is better than the strongest armor. Specters employ cutting-edge optical-electronic camouflage to vanish from the battlefield and enemy scans. They flicker in and out of vision, confusing the eye and the radar. That’s what makes them so deadly, though their weapons certainly help.",
@@ -2533,7 +2533,7 @@
     },
     {
         "id": "npc-rebake_npcc_support",
-        "name": "SUPPORT [K]",
+        "name": "Support [K]",
         "role": "support",
         "info": {
             "flavor": "Support-archetype mechs keep their allies alive and operational with a broad library of immediate triage systems, from basic flash-weld plating through to shallow–medium structural reinforcement packs and whitewash nanite slurry. From the famed Laughter of a Solemn God, working the front lines of Boundary Garden’s battlefields, to the precision actions undertaken by the rogue-world hunters of ExtraSolar Acquisitions, Inc., the efficacy of Support-archetype mechs is unparalleled when mech teams need to stay alive longer than deployment.",
@@ -2633,7 +2633,7 @@
     },
     {
         "id": "npc-rebake_npcc_witch",
-        "name": "WITCH [K]",
+        "name": "Witch [K]",
         "role": "controller",
         "info": {
             "flavor": "Witch-archetype chassis can always be found in the eye of a systemic storm, where they are adept at generating realspace and legionspace terrors to blanket battlefields. At any given time, they are likely to be operating in both the physical battlefield and the tempest of the omninet. To handle the chaotic swirl of inputs and outputs that results from this split perception, Witches often pair with personality-clone NHPs, splitting tasks along parallel tracks to increase combat efficacy.",

--- a/NPC Rebakes/npc_features.json
+++ b/NPC Rebakes/npc_features.json
@@ -1,5060 +1,5060 @@
 [
-    {
-        "id": "npc-rebake_npcf_ssc_flight_system_ace",
-        "name": "SSC Flight System",
-        "origin": {
-            "type": "Class",
-            "name": "Ace [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Ace can count any or all of their movement as <strong>flying</strong>.",
-        "tags": []
+  {
+    "id": "npc-rebake_npcf_ssc_flight_system_ace",
+    "name": "SSC Flight System",
+    "origin": {
+      "type": "Class",
+      "name": "Ace [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_missile_launcher_ace",
-        "name": "Missile Launcher",
-        "origin": {
-            "type": "Class",
-            "name": "Ace [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "Attacks made with this weapon against targets that have <strong>Lock On</strong> ignore cover.",
-        "tags": [
-            {
-                "id": "tg_smart"
-            }
-        ],
-        "weapon_type": "Main Launcher",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "System",
+    "effect": "The Ace can count any or all of their movement as <strong>flying</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_missile_launcher_ace",
+    "name": "Missile Launcher",
+    "origin": {
+      "type": "Class",
+      "name": "Ace [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "Attacks made with this weapon against targets that have <strong>Lock On</strong> ignore cover.",
+    "tags": [
+      {
+        "id": "tg_smart"
+      }
+    ],
+    "weapon_type": "Main Launcher",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Explosive",
         "damage": [
-            {
-                "type": "Explosive",
-                "damage": [
-                    4,
-                    6,
-                    8
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 10
-            },
-            {
-                "type": "Blast",
-                "val": 1
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_barrel_roll_ace",
-        "name": "Barrel Roll",
-        "origin": {
-            "type": "Class",
-            "name": "Ace [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Ace performs a barrel roll, flying <strong>6 spaces</strong> in any direction and causing the attack to miss. This movement ignores engagement and does not provoke reactions. This reaction can't be used if the Ace can't move (e.g. if it's <strong>Slowed</strong> or <strong>Immobilized</strong>).",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "A melee or ranged attack hits the Ace."
-    },
-    {
-        "id": "npc-rebake_npcf_strafe_ace",
-        "name": "Strafe",
-        "origin": {
-            "type": "Class",
-            "name": "Ace [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "<strong>1/round</strong>, the Ace can fly spaces equal to their <strong>Speed</strong> in any direction, automatically dealing <strong>{3/4/5} kinetic damage</strong> to one character below or adjacent to the path taken, plus any number of additional characters below or adjacent to the path taken who have <strong>Lock On</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
+          4,
+          6,
+          8
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      },
+      {
+        "type": "Blast",
+        "val": 1
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_barrel_roll_ace",
+    "name": "Barrel Roll",
+    "origin": {
+      "type": "Class",
+      "name": "Ace [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_missile_swarm_ace",
-        "name": "Missile Swarm",
-        "origin": {
-            "type": "Class",
-            "name": "Ace [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "This weapon deals double damage to characters with <strong>Lock On</strong>, and doesn’t affect allied characters.",
-        "tags": [
-            {
-                "id": "tg_loading"
-            }
-        ],
-        "weapon_type": "Main Launcher",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Ace performs a barrel roll, flying <strong>6 spaces</strong> in any direction and causing the attack to miss. This movement ignores engagement and does not provoke reactions. This reaction can't be used if the Ace can't move (e.g. if it's <strong>Slowed</strong> or <strong>Immobilized</strong>).",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "A melee or ranged attack hits the Ace."
+  },
+  {
+    "id": "npc-rebake_npcf_strafe_ace",
+    "name": "Strafe",
+    "origin": {
+      "type": "Class",
+      "name": "Ace [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "<strong>1/round</strong>, the Ace can fly spaces equal to their <strong>Speed</strong> in any direction, automatically dealing <strong>{3/4/5} kinetic damage</strong> to one character below or adjacent to the path taken, plus any number of additional characters below or adjacent to the path taken who have <strong>Lock On</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_missile_swarm_ace",
+    "name": "Missile Swarm",
+    "origin": {
+      "type": "Class",
+      "name": "Ace [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "This weapon deals double damage to characters with <strong>Lock On</strong>, and doesn’t affect allied characters.",
+    "tags": [
+      {
+        "id": "tg_loading"
+      }
+    ],
+    "weapon_type": "Main Launcher",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Explosive",
         "damage": [
-            {
-                "type": "Explosive",
-                "damage": [
-                    3,
-                    4,
-                    5
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Burst",
-                "val": 5
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_full_throttle_ace",
-        "name": "Full Throttle",
-        "origin": {
-            "type": "Class",
-            "name": "Ace [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Ace moves <strong>10 spaces</strong> in any direction and gains <strong>soft cover</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_reaction"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 5
-            }
-        ],
-        "trigger": "An enemy character in line of sight moves."
-    },
-    {
-        "id": "npc-rebake_npcf_countermeasures_ace",
-        "name": "Countermeasures",
-        "origin": {
-            "type": "Class",
-            "name": "Ace [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "Whenever the Ace would gain a condition from a hostile character, it may spend a charge from this system to ignore that condition. The Ace then takes <strong>4 Heat</strong>, and the character that inflicted that condition gains <strong>Lock On</strong>.",
-        "tags": [
-            {
-                "id": "tg_limited",
-                "val": "1"
-            }
+          3,
+          4,
+          5
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Burst",
+        "val": 5
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_full_throttle_ace",
+    "name": "Full Throttle",
+    "origin": {
+      "type": "Class",
+      "name": "Ace [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_emergency_jettison_ace",
-        "name": "Emergency Jettison",
-        "origin": {
-            "type": "Class",
-            "name": "Ace [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Whenever the Ace is destroyed, it instead moves up to its <strong>Speed</strong> and immediately lands, remaining at <strong>1 HP</strong>. The <strong>SSC Flight System</strong> is then permanently destroyed, and all of the Ace's other systems and traits are disabled. If the <strong>SSC Flight System</strong> is already destroyed, this trait has no effect.",
-        "tags": []
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Ace moves <strong>10 spaces</strong> in any direction and gains <strong>soft cover</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_reaction"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 5
+      }
+    ],
+    "trigger": "An enemy character in line of sight moves."
+  },
+  {
+    "id": "npc-rebake_npcf_countermeasures_ace",
+    "name": "Countermeasures",
+    "origin": {
+      "type": "Class",
+      "name": "Ace [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_light_laser_aegis",
-        "name": "Light Laser",
-        "origin": {
-            "type": "Class",
-            "name": "Aegis [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [],
-        "weapon_type": "Main Cannon",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "System",
+    "effect": "Whenever the Ace would gain a condition from a hostile character, it may spend a charge from this system to ignore that condition. The Ace then takes <strong>4 Heat</strong>, and the character that inflicted that condition gains <strong>Lock On</strong>.",
+    "tags": [
+      {
+        "id": "tg_limited",
+        "val": "1"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_emergency_jettison_ace",
+    "name": "Emergency Jettison",
+    "origin": {
+      "type": "Class",
+      "name": "Ace [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "Whenever the Ace is destroyed, it instead moves up to its <strong>Speed</strong> and immediately lands, remaining at <strong>1 HP</strong>. The <strong>SSC Flight System</strong> is then permanently destroyed, and all of the Ace's other systems and traits are disabled. If the <strong>SSC Flight System</strong> is already destroyed, this trait has no effect.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_light_laser_aegis",
+    "name": "Light Laser",
+    "origin": {
+      "type": "Class",
+      "name": "Aegis [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [],
+    "weapon_type": "Main Cannon",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Energy",
         "damage": [
-            {
-                "type": "Energy",
-                "damage": [
-                    3,
-                    3,
-                    3
-                ]
-            },
-            {
-                "type": "Burn",
-                "damage": [
-                    2,
-                    3,
-                    4
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 8
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_defense_net_aegis",
-        "name": "Defense Net",
-        "origin": {
-            "type": "Class",
-            "name": "Aegis [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Aegis spreads a powerful, shimmering repulsion shield over a <strong>Burst 2</strong> area. While active, the Aegis is <strong>Immobilized</strong>, but all ranged, melee, and tech attacks against characters or objects within the affected area that originate outside the area receive <strong>+2 Difficulty</strong> and cannot result in <strong>critical hits</strong>; whenever an attack receiving this <strong>Difficulty</strong> misses, the Aegis takes <strong>2 Heat</strong>. Characters within the affected area may attack characters within and outside of the area normally.<br>Allied characters within the affected area also gain <strong>Immunity</strong> to <strong>Impaired</strong> and <strong>Slowed</strong>, and remove these conditions when they enter the area if they already have them.<br>This effect lasts until the Aegis ends it as a <strong>protocol</strong> or is destroyed. If the Aegis exceeds their <strong>Heat Cap</strong>, becomes <strong>Stunned</strong>, or becomes <strong>Jammed</strong> while the shield is active, the shield deactivates and can't be reactivated until the end of the Aegis' next turn.",
-        "tags": [
-            {
-                "id": "tg_shield"
-            },
-            {
-                "id": "tg_full_action"
-            }
+          3,
+          3,
+          3
         ]
-    },
-    {
-        "id": "npc-rebake_npcf_regenerative_shielding_aegis",
-        "name": "Regenerative Shielding",
-        "origin": {
-            "type": "Class",
-            "name": "Aegis [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Aegis has <strong>Immunity</strong> to <strong>Impaired</strong> and <strong>Slowed</strong> and can’t be critically hit.",
-        "immunity": [
-            "Impaired",
-            "Slowed",
-            "Critical Hits"
-        ],
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_focused_shielding_aegis",
-        "name": "Focused Shielding",
-        "origin": {
-            "type": "Class",
-            "name": "Aegis [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "That character gains <strong>resistance to all damage from the attack</strong>, then the <strong>Defense Net</strong> is deactivated.",
-        "tags": [
-            {
-                "id": "tg_reaction"
-            },
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ],
-        "trigger": "An allied character within your <strong>Defense Net</strong> area is hit by a ranged or melee attack."
-    },
-    {
-        "id": "npc-rebake_npcf_guardian_aegis",
-        "name": "Guardian",
-        "origin": {
-            "type": "Class",
-            "name": "Aegis [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Allied characters can use the Aegis for <strong>hard cover</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_ring_of_fire_aegis",
-        "name": "Ring of Fire",
-        "origin": {
-            "type": "Class",
-            "name": "Aegis [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Any hostile characters that start their turn inside the area affected by the <strong>Defense Net</strong> or that enter it for the first time in a round take <strong>2 Heat</strong> and become <strong>Shredded</strong> until they leave the area.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_remote_projector_aegis",
-        "name": "Remote Projector",
-        "origin": {
-            "type": "Class",
-            "name": "Aegis [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When the Aegis activates <strong>Defense Net</strong>, it may choose a free space within <strong>Range 10</strong> and generate a <strong>Burst 2</strong> area centered on that space instead. All other effects of <strong>Defense Net</strong> remain the same while this remote field is active (e.g. the Aegis is <strong>Immobilized</strong>, etc).",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_ha_blackwall_system_aegis",
-        "name": "HA Blackwall System",
-        "origin": {
-            "type": "Class",
-            "name": "Aegis [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "As a full action, the Aegis generates a pitch-black wall of blinkspace <strong>5 spaces high</strong> covering a <strong>line 10</strong> area starting within <strong>range 5</strong>. All spaces must be free. The wall blocks line of sight, effects or attacks and provides <strong>hard cover</strong>. Characters that start their turn in the wall or who enter it on their turn roll <strong>1d6</strong>. On a <strong>4+</strong> they are removed from play until the end of their next turn, when they reappear in a free space of their choice in <strong>Range 10</strong> of the wall. If there are no free spaces, they return when a space becomes free. The wall lasts until the Aegis ends it as a <strong>quick action</strong>, or is destroyed. When it ends, characters remaining in blinkspace reappear.",
-        "tags": [
-            {
-                "id": "tg_limited",
-                "val": 1
-            },
-            {
-                "id": "tg_full_action"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_light_machine_gun_archer",
-        "name": "Light Machine Gun",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_reliable",
-                "val": "{3/4/5}"
-            }
-        ],
-        "weapon_type": "Main Cannon",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+      },
+      {
+        "type": "Burn",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    5,
-                    6,
-                    7
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 10
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_suppress_archer",
-        "name": "Suppress",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Archer chooses a target within line of sight and <strong>Range 10</strong>: they become <strong>Impaired</strong> and the Archer gains the <strong>Moving Target</strong> reaction.<br>This effect lasts until the Archer uses <strong>Moving Target</strong>; the target damages the Archer or leaves the Archer’s line of sight; the Archer is <strong>Stunned</strong>, <strong>Jammed</strong>, or destroyed; the Archer chooses a new target for this action; or, the Archer ends it as a free action.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": ""
-    },
-    {
-        "id": "npc-rebake_npcf_moving_target_archer",
-        "name": "Moving Target",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Archer makes an attack against them with the <strong>Light Machine Gun</strong>. This attack interrupts and resolves before the triggering movement",
-        "tags": [
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "The Archer’s <strong>Suppress</strong> target starts to move."
-    },
-    {
-        "id": "npc-rebake_npcf_superior_sentinel_archer",
-        "name": "Superior Sentinel",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Archer gains <strong>+1 Accuracy</strong> on all attacks made as reactions (e.g., <strong>Overwatch</strong>).",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_covering_fire_archer",
-        "name": "Covering Fire",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Archer creates a <strong>Blast 3</strong> area within <strong>Range 10</strong> and line of sight, and gains the <strong>Got Your Back</strong> reaction. This area lasts until the end of the Archer's next turn or until the Archer creates a new area, and this Reaction can be taken as many times per round as it is triggered.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 4
-            },
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_reaction"
-            }
+          2,
+          3,
+          4
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 8
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_defense_net_aegis",
+    "name": "Defense Net",
+    "origin": {
+      "type": "Class",
+      "name": "Aegis [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_got_your_back_archer",
-        "name": "Got Your Back",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Archer may attack that character with the <strong>Light Machine Gun</strong>.",
-        "tags": [
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "A character in the <strong>Covering Fire</strong> area makes an attack."
+    "locked": false,
+    "type": "System",
+    "effect": "The Aegis spreads a powerful, shimmering repulsion shield over a <strong>Burst 2</strong> area. While active, the Aegis is <strong>Immobilized</strong>, but all ranged, melee, and tech attacks against characters or objects within the affected area that originate outside the area receive <strong>+2 Difficulty</strong> and cannot result in <strong>critical hits</strong>; whenever an attack receiving this <strong>Difficulty</strong> misses, the Aegis takes <strong>2 Heat</strong>. Characters within the affected area may attack characters within and outside of the area normally.<br>Allied characters within the affected area also gain <strong>Immunity</strong> to <strong>Impaired</strong> and <strong>Slowed</strong>, and remove these conditions when they enter the area if they already have them.<br>This effect lasts until the Aegis ends it as a <strong>protocol</strong> or is destroyed. If the Aegis exceeds their <strong>Heat Cap</strong>, becomes <strong>Stunned</strong>, or becomes <strong>Jammed</strong> while the shield is active, the shield deactivates and can't be reactivated until the end of the Aegis' next turn.",
+    "tags": [
+      {
+        "id": "tg_shield"
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_regenerative_shielding_aegis",
+    "name": "Regenerative Shielding",
+    "origin": {
+      "type": "Class",
+      "name": "Aegis [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_impending_threat_archer",
-        "name": "Impending Threat",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "<strong>Moving Target</strong>'s trigger now includes the target taking any action that does not target the Archer",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Aegis has <strong>Immunity</strong> to <strong>Impaired</strong> and <strong>Slowed</strong> and can’t be critically hit.",
+    "immunity": [
+      "Impaired",
+      "Slowed",
+      "Critical Hits"
+    ],
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_focused_shielding_aegis",
+    "name": "Focused Shielding",
+    "origin": {
+      "type": "Class",
+      "name": "Aegis [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_flush_out_archer",
-        "name": "Flush Out",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Archer chooses a character within <strong>Range 10</strong>: that character must either move their <strong>Speed</strong> in a direction of the Archer's choice, or allow the Archer to attack them with the <strong>Light Machine Gun</strong>. This movement ignores engagement and does not provoke reactions.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 4
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Reaction",
+    "effect": "That character gains <strong>resistance to all damage from the attack</strong>, then the <strong>Defense Net</strong> is deactivated.",
+    "tags": [
+      {
+        "id": "tg_reaction"
+      },
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ],
+    "trigger": "An allied character within your <strong>Defense Net</strong> area is hit by a ranged or melee attack."
+  },
+  {
+    "id": "npc-rebake_npcf_guardian_aegis",
+    "name": "Guardian",
+    "origin": {
+      "type": "Class",
+      "name": "Aegis [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_blinding_shells_archer",
-        "name": "Blinding Shells",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "After the Archer makes a successful attack, they may force their target to pass an <strong>Engineering</strong> save. On a failure, the target only has line of sight to adjacent spaces until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "Allied characters can use the Aegis for <strong>hard cover</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_ring_of_fire_aegis",
+    "name": "Ring of Fire",
+    "origin": {
+      "type": "Class",
+      "name": "Aegis [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_fire_and_maneuver_archer",
-        "name": "Fire and Maneuver",
-        "origin": {
-            "type": "Class",
-            "name": "Archer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Archer may <strong>Boost</strong>. If they end this movement within <strong>Range 10</strong> and line of sight of the triggering character, that character takes <strong>{3/4/5} kinetic damage</strong>.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "An enemy character in line of sight moves."
+    "locked": false,
+    "type": "Trait",
+    "effect": "Any hostile characters that start their turn inside the area affected by the <strong>Defense Net</strong> or that enter it for the first time in a round take <strong>2 Heat</strong> and become <strong>Shredded</strong> until they leave the area.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_remote_projector_aegis",
+    "name": "Remote Projector",
+    "origin": {
+      "type": "Class",
+      "name": "Aegis [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_kai_bioplating_assassin",
-        "name": "Kai Bioplating",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Assassin gains <strong>+1 Accuracy</strong> on all <strong>Agility</strong> checks; additionally, they climb and swim at normal speed, ignore <strong>difficult terrain</strong>, and, when making a standard move, can jump horizontally up to their <strong>Speed</strong> and vertically up to half their <strong>Speed</strong> (in any combination).",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "When the Aegis activates <strong>Defense Net</strong>, it may choose a free space within <strong>Range 10</strong> and generate a <strong>Burst 2</strong> area centered on that space instead. All other effects of <strong>Defense Net</strong> remain the same while this remote field is active (e.g. the Aegis is <strong>Immobilized</strong>, etc).",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_ha_blackwall_system_aegis",
+    "name": "HA Blackwall System",
+    "origin": {
+      "type": "Class",
+      "name": "Aegis [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_heated_blade_assassin",
-        "name": "Heated Blade",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "Deals double damage to <strong>Prone</strong>, <strong>Shredded</strong>, <strong>Immobilized</strong>, or <strong>Stunned</strong> targets.",
-        "tags": [],
-        "weapon_type": "Main Melee",
-        "attack_bonus": [
-            2,
-            3,
-            4
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ],
+    "locked": false,
+    "type": "System",
+    "effect": "As a full action, the Aegis generates a pitch-black wall of blinkspace <strong>5 spaces high</strong> covering a <strong>line 10</strong> area starting within <strong>range 5</strong>. All spaces must be free. The wall blocks line of sight, effects or attacks and provides <strong>hard cover</strong>. Characters that start their turn in the wall or who enter it on their turn roll <strong>1d6</strong>. On a <strong>4+</strong> they are removed from play until the end of their next turn, when they reappear in a free space of their choice in <strong>Range 10</strong> of the wall. If there are no free spaces, they return when a space becomes free. The wall lasts until the Aegis ends it as a <strong>quick action</strong>, or is destroyed. When it ends, characters remaining in blinkspace reappear.",
+    "tags": [
+      {
+        "id": "tg_limited",
+        "val": 1
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_light_machine_gun_archer",
+    "name": "Light Machine Gun",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_reliable",
+        "val": "{3/4/5}"
+      }
+    ],
+    "weapon_type": "Main Cannon",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "Kinetic",
-                "damage": [
-                    4,
-                    5,
-                    6
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 2
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_assassins_mark_assassin",
-        "name": "Assassin’s Mark",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Assassin chooses a character in line of sight. For the rest of the scene, these effects apply:<ul><li>It has Resistance to that target’s damage.</li><li>Damage it deals to that target cannot be reduced.</li><li>It gains <strong>+1 Accuracy</strong> on all saves forced by that target.</li></ul><br>The Assassin can only choose a new target if the current target is destroyed.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
+          5,
+          6,
+          7
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_suppress_archer",
+    "name": "Suppress",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_leap_assassin",
-        "name": "Leap",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Assassin flies <strong>6 spaces</strong> in any direction but must land on a surface. When they land, characters adjacent to the Assassin must succeed on an <strong>Agility</strong> save or be knocked <strong>Prone</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 5
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Archer chooses a target within line of sight and <strong>Range 10</strong>: they become <strong>Impaired</strong> and the Archer gains the <strong>Moving Target</strong> reaction.<br>This effect lasts until the Archer uses <strong>Moving Target</strong>; the target damages the Archer or leaves the Archer’s line of sight; the Archer is <strong>Stunned</strong>, <strong>Jammed</strong>, or destroyed; the Archer chooses a new target for this action; or, the Archer ends it as a free action.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": ""
+  },
+  {
+    "id": "npc-rebake_npcf_moving_target_archer",
+    "name": "Moving Target",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_devils_cough_shotgun_assassin",
-        "name": "“Devil’s Cough” Shotgun",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_knockback",
-                "val": 2
-            },
-            {
-                "id": "tg_loading"
-            }
-        ],
-        "weapon_type": "Heavy CQB",
-        "attack_bonus": [
-            0,
-            1,
-            2
-        ],
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Archer makes an attack against them with the <strong>Light Machine Gun</strong>. This attack interrupts and resolves before the triggering movement",
+    "tags": [
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "The Archer’s <strong>Suppress</strong> target starts to move."
+  },
+  {
+    "id": "npc-rebake_npcf_superior_sentinel_archer",
+    "name": "Superior Sentinel",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Archer gains <strong>+1 Accuracy</strong> on all attacks made as reactions (e.g., <strong>Overwatch</strong>).",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_covering_fire_archer",
+    "name": "Covering Fire",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Archer creates a <strong>Blast 3</strong> area within <strong>Range 10</strong> and line of sight, and gains the <strong>Got Your Back</strong> reaction. This area lasts until the end of the Archer's next turn or until the Archer creates a new area, and this Reaction can be taken as many times per round as it is triggered.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 4
+      },
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_got_your_back_archer",
+    "name": "Got Your Back",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Archer may attack that character with the <strong>Light Machine Gun</strong>.",
+    "tags": [
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "A character in the <strong>Covering Fire</strong> area makes an attack."
+  },
+  {
+    "id": "npc-rebake_npcf_impending_threat_archer",
+    "name": "Impending Threat",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "<strong>Moving Target</strong>'s trigger now includes the target taking any action that does not target the Archer",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_flush_out_archer",
+    "name": "Flush Out",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Archer chooses a character within <strong>Range 10</strong>: that character must either move their <strong>Speed</strong> in a direction of the Archer's choice, or allow the Archer to attack them with the <strong>Light Machine Gun</strong>. This movement ignores engagement and does not provoke reactions.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 4
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_blinding_shells_archer",
+    "name": "Blinding Shells",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "After the Archer makes a successful attack, they may force their target to pass an <strong>Engineering</strong> save. On a failure, the target only has line of sight to adjacent spaces until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_fire_and_maneuver_archer",
+    "name": "Fire and Maneuver",
+    "origin": {
+      "type": "Class",
+      "name": "Archer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Archer may <strong>Boost</strong>. If they end this movement within <strong>Range 10</strong> and line of sight of the triggering character, that character takes <strong>{3/4/5} kinetic damage</strong>.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "An enemy character in line of sight moves."
+  },
+  {
+    "id": "npc-rebake_npcf_kai_bioplating_assassin",
+    "name": "Kai Bioplating",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Assassin gains <strong>+1 Accuracy</strong> on all <strong>Agility</strong> checks; additionally, they climb and swim at normal speed, ignore <strong>difficult terrain</strong>, and, when making a standard move, can jump horizontally up to their <strong>Speed</strong> and vertically up to half their <strong>Speed</strong> (in any combination).",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_heated_blade_assassin",
+    "name": "Heated Blade",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "Deals double damage to <strong>Prone</strong>, <strong>Shredded</strong>, <strong>Immobilized</strong>, or <strong>Stunned</strong> targets.",
+    "tags": [],
+    "weapon_type": "Main Melee",
+    "attack_bonus": [
+      2,
+      3,
+      4
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ],
+    "damage": [
+      {
+        "type": "Kinetic",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    10,
-                    15,
-                    20
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 3
-            },
-            {
-                "type": "Threat",
-                "val": 3
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_spinning_kick_assassin",
-        "name": "Spinning Kick",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Assassin chooses a character next to them: they must pass a <strong>Hull</strong> save or be pushed <strong>4 spaces</strong> away from the Assassin and knocked <strong>Prone</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
+          4,
+          5,
+          6
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 2
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_assassins_mark_assassin",
+    "name": "Assassin’s Mark",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_shroud_projector_assassin",
-        "name": "Shroud Projector",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Assassin sets off a charge, creating a <strong>Burst 3</strong> concealing shroud. The Assassin gains <strong>soft cover</strong> within the affected area, and characters other than the Assassin fully inside or outside the area cannot draw line of sight into or out of the area. Characters partially within the area are not affected. The <strong>Heated Blade</strong> deals double damage to characters inside this area (as though they were <strong>Prone</strong> etc). This effect lasts until the end of the Assassin’s next turn, or until the Assassin uses this system again.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Assassin chooses a character in line of sight. For the rest of the scene, these effects apply:<ul><li>It has Resistance to that target’s damage.</li><li>Damage it deals to that target cannot be reduced.</li><li>It gains <strong>+1 Accuracy</strong> on all saves forced by that target.</li></ul><br>The Assassin can only choose a new target if the current target is destroyed.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_leap_assassin",
+    "name": "Leap",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_explosive_knives_assassin",
-        "name": "Explosive Knives",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Assassin throws an explosive knife at a character within <strong>Range 5</strong>, making a ranged attack at <strong>{+2/+4/+6}</strong>. On a hit, the knife embeds itself in the target and explodes at the end of their next turn, dealing <strong>{4/6/8} explosive damage</strong> in a <strong>Burst 1</strong> area and forcing the struck target to pass a <strong>Hull</strong> save or become <strong>Shredded</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Assassin flies <strong>6 spaces</strong> in any direction but must land on a surface. When they land, characters adjacent to the Assassin must succeed on an <strong>Agility</strong> save or be knocked <strong>Prone</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 5
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_devils_cough_shotgun_assassin",
+    "name": "“Devil’s Cough” Shotgun",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_transfix_assassin",
-        "name": "Transfix",
-        "origin": {
-            "type": "Class",
-            "name": "Assassin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Assassin jams their blade into a vital part of an adjacent character: that character must pass an <strong>Engineering</strong> save or become <strong>Stunned</strong>. While <strong>Stunned</strong> this way, the Assassin becomes <strong>Immobilized</strong>.This effect lasts until the Assassin and the target are no longer adjacent or until the target takes <strong>structure damage</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_quick_tech"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_weapon_heavy_assault",
-        "name": "Heavy Assault Rifle",
-        "origin": {
-            "type": "Class",
-            "name": "Assault [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "This weapon gains <strong>+1 Accuracy</strong> against targets that do not have <strong>cover.</strong>",
-        "tags": [],
-        "weapon_type": "Heavy Rifle",
-        "attack_bonus": [
-            0,
-            1,
-            2
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_knockback",
+        "val": 2
+      },
+      {
+        "id": "tg_loading"
+      }
+    ],
+    "weapon_type": "Heavy CQB",
+    "attack_bonus": [
+      0,
+      1,
+      2
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "Kinetic",
-                "damage": [
-                    6,
-                    8,
-                    10
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 10
-            }
+          10,
+          15,
+          20
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 3
+      },
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_spinning_kick_assassin",
+    "name": "Spinning Kick",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_weapon_combat_knife",
-        "name": "Combat Knife",
-        "origin": {
-            "type": "Class",
-            "name": "Assault [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "tags": [],
-        "weapon_type": "Auxiliary Melee",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Assassin chooses a character next to them: they must pass a <strong>Hull</strong> save or be pushed <strong>4 spaces</strong> away from the Assassin and knocked <strong>Prone</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_shroud_projector_assassin",
+    "name": "Shroud Projector",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Assassin sets off a charge, creating a <strong>Burst 3</strong> concealing shroud. The Assassin gains <strong>soft cover</strong> within the affected area, and characters other than the Assassin fully inside or outside the area cannot draw line of sight into or out of the area. Characters partially within the area are not affected. The <strong>Heated Blade</strong> deals double damage to characters inside this area (as though they were <strong>Prone</strong> etc). This effect lasts until the end of the Assassin’s next turn, or until the Assassin uses this system again.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_explosive_knives_assassin",
+    "name": "Explosive Knives",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Assassin throws an explosive knife at a character within <strong>Range 5</strong>, making a ranged attack at <strong>{+2/+4/+6}</strong>. On a hit, the knife embeds itself in the target and explodes at the end of their next turn, dealing <strong>{4/6/8} explosive damage</strong> in a <strong>Burst 1</strong> area and forcing the struck target to pass a <strong>Hull</strong> save or become <strong>Shredded</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_transfix_assassin",
+    "name": "Transfix",
+    "origin": {
+      "type": "Class",
+      "name": "Assassin [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Assassin jams their blade into a vital part of an adjacent character: that character must pass an <strong>Engineering</strong> save or become <strong>Stunned</strong>. While <strong>Stunned</strong> this way, the Assassin becomes <strong>Immobilized</strong>.This effect lasts until the Assassin and the target are no longer adjacent or until the target takes <strong>structure damage</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_quick_tech"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_weapon_heavy_assault",
+    "name": "Heavy Assault Rifle",
+    "origin": {
+      "type": "Class",
+      "name": "Assault [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "This weapon gains <strong>+1 Accuracy</strong> against targets that do not have <strong>cover.</strong>",
+    "tags": [],
+    "weapon_type": "Heavy Rifle",
+    "attack_bonus": [
+      0,
+      1,
+      2
+    ],
+    "damage": [
+      {
+        "type": "Kinetic",
         "damage": [
-            {
-                "type": "Kinetic",
-                "damage": [
-                    4,
-                    5,
-                    6
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 1
-            }
+          6,
+          8,
+          10
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_weapon_combat_knife",
+    "name": "Combat Knife",
+    "origin": {
+      "type": "Class",
+      "name": "Assault [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_trait_hunker_down",
-        "name": "Hunker Down",
-        "origin": {
-            "type": "Class",
-            "name": "Assault [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Assault gains <strong>Resistance to all damage from the attack</strong>, but becomes <strong>Slowed</strong> until the end of its next turn.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ],
-        "trigger": "An attack hits the Assault, but damage hasn't been rolled yet."
-    },
-    {
-        "id": "npc-rebake_npcf_trait_rank_discipline",
-        "name": "Rank Discipline",
-        "origin": {
-            "type": "Class",
-            "name": "Assault [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Assault gains <strong>+1 Accuracy</strong> on all attacks, checks, and saves while adjacent to at least one allied character with the <strong>Mech</strong> tag.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_weapon_underslung_grenade",
-        "name": "Underslung Grenade Launcer",
-        "origin": {
-            "type": "Class",
-            "name": "Assault [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_knockback",
-                "val": 2
-            },
-            {
-                "id": "tg_loading"
-            }
-        ],
-        "weapon_type": "Auxiliary Launcher",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "tags": [],
+    "weapon_type": "Auxiliary Melee",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Kinetic",
         "damage": [
-            {
-                "type": "Explosive",
-                "damage": [
-                    4,
-                    6,
-                    8
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 10
-            },
-            {
-                "type": "Blast",
-                "val": 1
-            }
+          4,
+          5,
+          6
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_trait_hunker_down",
+    "name": "Hunker Down",
+    "origin": {
+      "type": "Class",
+      "name": "Assault [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_system_micromissile_barrage",
-        "name": "Micro-Missile Barrage",
-        "origin": {
-            "type": "Class",
-            "name": "Assault [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Assault launches a <strong>Line 10</strong> volley of micro-missiles. All characters within the affected area must succeed on a <strong>Hull</strong> save or take {6/8/10} explosive damage. On a successful save, they take half damage.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Assault gains <strong>Resistance to all damage from the attack</strong>, but becomes <strong>Slowed</strong> until the end of its next turn.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ],
+    "trigger": "An attack hits the Assault, but damage hasn't been rolled yet."
+  },
+  {
+    "id": "npc-rebake_npcf_trait_rank_discipline",
+    "name": "Rank Discipline",
+    "origin": {
+      "type": "Class",
+      "name": "Assault [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_trait_flank_and_fix",
-        "name": "Fix and Flank",
-        "origin": {
-            "type": "Class",
-            "name": "Assault [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Assault may target them with <strong>Overwatch</strong> using the <strong>Heavy Assault Rifle</strong>, dealing half damage on hit.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ],
-        "trigger": "A character who doesn't have cover from the Assault is successfully attacked by an allied character."
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Assault gains <strong>+1 Accuracy</strong> on all attacks, checks, and saves while adjacent to at least one allied character with the <strong>Mech</strong> tag.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_weapon_underslung_grenade",
+    "name": "Underslung Grenade Launcer",
+    "origin": {
+      "type": "Class",
+      "name": "Assault [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_trait_stormtrooper",
-        "name": "Stormtrooper",
-        "origin": {
-            "type": "Class",
-            "name": "Assault [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "<strong>Hunker Down</strong> no longer causes the Assault to become <strong>Slowed</strong>. Whenever the Assault uses <strong>Hunker Down</strong>, they may also move up to their <strong>Speed</strong> as part of the Reaction.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_graviton_lance_barricade",
-        "name": "Graviton Lance",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "tags": [],
-        "weapon_type": "Main Cannon",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_knockback",
+        "val": 2
+      },
+      {
+        "id": "tg_loading"
+      }
+    ],
+    "weapon_type": "Auxiliary Launcher",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Explosive",
         "damage": [
-            {
-                "type": "Energy",
-                "damage": [
-                    2,
-                    3,
-                    4
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 10
-            }
-        ],
-        "on_hit": "Target is <strong>Slowed</strong> until the end of their next turn."
-    },
-    {
-        "id": "npc-rebake_npcf_mobile_printer_barricade",
-        "name": "Mobile Printer",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Barricade prints a <strong>Size 2</strong> cube in a free area within <strong>Range 3</strong>. The cube provides <strong>hard cover</strong> and is a single object with <strong>20 HP</strong> and <strong>Evasion 5</strong>. The Barricade can only have one cube deployed at a time; if a new one is deployed, the first one dissolves.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
+          4,
+          6,
+          8
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      },
+      {
+        "type": "Blast",
+        "val": 1
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_system_micromissile_barrage",
+    "name": "Micro-Missile Barrage",
+    "origin": {
+      "type": "Class",
+      "name": "Assault [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_drag_down_barricade",
-        "name": "Drag Down",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Barricade makes a tech attack against a character within <strong>Sensors</strong>. On a success, they take <strong>2 AP Energy damage</strong> per space that they voluntarily move until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Assault launches a <strong>Line 10</strong> volley of micro-missiles. All characters within the affected area must succeed on a <strong>Hull</strong> save or take {6/8/10} explosive damage. On a successful save, they take half damage.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_trait_flank_and_fix",
+    "name": "Fix and Flank",
+    "origin": {
+      "type": "Class",
+      "name": "Assault [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_bulwark_mods_barricade",
-        "name": "Bulwark Mods",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Barricade ignores <strong>difficult terrain</strong> and <strong>dangerous terrain</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Assault may target them with <strong>Overwatch</strong> using the <strong>Heavy Assault Rifle</strong>, dealing half damage on hit.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ],
+    "trigger": "A character who doesn't have cover from the Assault is successfully attacked by an allied character."
+  },
+  {
+    "id": "npc-rebake_npcf_trait_stormtrooper",
+    "name": "Stormtrooper",
+    "origin": {
+      "type": "Class",
+      "name": "Assault [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_spike_barrier_barricade",
-        "name": "Spike Barrier",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The cube printed by Mobile Printer is covered in piercing spikes; the first time in a round any character moves adjacent to it, that character takes <strong>{2/3/4} AP kinetic damage</strong> and must pass an <strong>Agility</strong> save or lose all their remaining movement as though they had become <strong>Engaged</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "<strong>Hunker Down</strong> no longer causes the Assault to become <strong>Slowed</strong>. Whenever the Assault uses <strong>Hunker Down</strong>, they may also move up to their <strong>Speed</strong> as part of the Reaction.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_graviton_lance_barricade",
+    "name": "Graviton Lance",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_extrudite_barricade",
-        "name": "Extrudite",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Barricade can print two separate cubes at a time with instead of one, and cubes no longer dissolve when new ones are printed. Replace <strong>Mobile Printer</strong> with <strong>Extruding Printer</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_extruding_printer_barricade",
-        "name": "Extruding Printer",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Barricade prints 2 <strong>Size 2</strong> cubes in free areas within <strong>Range 3</strong>. The cubes provides <strong>hard cover</strong> and are each single objects with <strong>20 HP</strong> and <strong>Evasion 5</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_seismic_repulsor_barricade",
-        "name": "Seismic Repulsor",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Barricade emits a seismic pulse from one of its printed cubes, creating a <strong>Burst 3</strong> area around it. All non-flying characters within that area must pass a <strong>Hull</strong> save or be knocked <strong>3 spaces</strong> back from the cube and knocked <strong>Prone</strong>. Allied characters affected this way (including the Barricade itself) are not knocked <strong>Prone</strong>. The cube is then destroyed.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_hunger_pursuit_limpets_barricade",
-        "name": "Hunger/Pursuit Limpets",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Barricade rapidly prints and deploys a field of tiny, mobile mines in a free <strong>Size 4</strong> area adjacent to them. The affected area becomes <strong>difficult terrain</strong>; additionally, hostile characters that enter the area forthe first time in a round or start their turn there must pass a <strong>Systems</strong> save or be <strong>Slowed</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_titan_snare_drone_barricade",
-        "name": "Titan-Snare Drone",
-        "origin": {
-            "type": "Class",
-            "name": "Barricade [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "Snare Drone (<strong>Size 1/2,</strong> <strong>HP {5/8/10}</strong>, <strong>Evasion {10/12/14}</strong>, <strong>E-Defense {10/12/14}</strong>, Tags: Drone)<br>This drone can be printed and deployed to any free adjacent space. When hostile characters move into or start their turn within <strong>Range 3</strong> of the drone, it emits a pulse, and they become <strong>Immobilized</strong> until the drone is destroyed.",
-        "tags": [
-            {
-                "id": "tg_drone"
-            },
-            {
-                "id": "tg_limited",
-                "val": 1
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_rotary_grenade_launcher_bastion",
-        "name": "Rotary Grenade Launcher",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "An adjacent allied character can spend a <strong>quick action</strong> to reload this weapon.",
-        "tags": [
-            {
-                "id": "tg_arcing"
-            },
-            {
-                "id": "tg_loading"
-            }
-        ],
-        "weapon_type": "Main Launcher",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "tags": [],
+    "weapon_type": "Main Cannon",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ],
+    "damage": [
+      {
+        "type": "Energy",
         "damage": [
-            {
-                "type": "Explosive",
-                "damage": [
-                    4,
-                    6,
-                    8
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 8
-            },
-            {
-                "type": "Blast",
-                "val": 1
-            }
-        ],
-        "on_hit": ""
+          2,
+          3,
+          4
+        ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
+    "on_hit": "Target is <strong>Slowed</strong> until the end of their next turn."
+  },
+  {
+    "id": "npc-rebake_npcf_mobile_printer_barricade",
+    "name": "Mobile Printer",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_heavy_assault_shield_bastion",
-        "name": "Heavy Assault Shield",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_knockback",
-                "val": 1
-            }
-        ],
-        "weapon_type": "Heavy Melee",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "System",
+    "effect": "The Barricade prints a <strong>Size 2</strong> cube in a free area within <strong>Range 3</strong>. The cube provides <strong>hard cover</strong> and is a single object with <strong>20 HP</strong> and <strong>Evasion 5</strong>. The Barricade can only have one cube deployed at a time; if a new one is deployed, the first one dissolves.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_drag_down_barricade",
+    "name": "Drag Down",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Barricade makes a tech attack against a character within <strong>Sensors</strong>. On a success, they take <strong>2 AP Energy damage</strong> per space that they voluntarily move until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_bulwark_mods_barricade",
+    "name": "Bulwark Mods",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Barricade ignores <strong>difficult terrain</strong> and <strong>dangerous terrain</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_spike_barrier_barricade",
+    "name": "Spike Barrier",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The cube printed by Mobile Printer is covered in piercing spikes; the first time in a round any character moves adjacent to it, that character takes <strong>{2/3/4} AP kinetic damage</strong> and must pass an <strong>Agility</strong> save or lose all their remaining movement as though they had become <strong>Engaged</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_extrudite_barricade",
+    "name": "Extrudite",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Barricade can print two separate cubes at a time with instead of one, and cubes no longer dissolve when new ones are printed. Replace <strong>Mobile Printer</strong> with <strong>Extruding Printer</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_extruding_printer_barricade",
+    "name": "Extruding Printer",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Barricade prints 2 <strong>Size 2</strong> cubes in free areas within <strong>Range 3</strong>. The cubes provides <strong>hard cover</strong> and are each single objects with <strong>20 HP</strong> and <strong>Evasion 5</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_seismic_repulsor_barricade",
+    "name": "Seismic Repulsor",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Barricade emits a seismic pulse from one of its printed cubes, creating a <strong>Burst 3</strong> area around it. All non-flying characters within that area must pass a <strong>Hull</strong> save or be knocked <strong>3 spaces</strong> back from the cube and knocked <strong>Prone</strong>. Allied characters affected this way (including the Barricade itself) are not knocked <strong>Prone</strong>. The cube is then destroyed.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_hunger_pursuit_limpets_barricade",
+    "name": "Hunger/Pursuit Limpets",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Barricade rapidly prints and deploys a field of tiny, mobile mines in a free <strong>Size 4</strong> area adjacent to them. The affected area becomes <strong>difficult terrain</strong>; additionally, hostile characters that enter the area forthe first time in a round or start their turn there must pass a <strong>Systems</strong> save or be <strong>Slowed</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_titan_snare_drone_barricade",
+    "name": "Titan-Snare Drone",
+    "origin": {
+      "type": "Class",
+      "name": "Barricade [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "Snare Drone (<strong>Size 1/2,</strong> <strong>HP {5/8/10}</strong>, <strong>Evasion {10/12/14}</strong>, <strong>E-Defense {10/12/14}</strong>, Tags: Drone)<br>This drone can be printed and deployed to any free adjacent space. When hostile characters move into or start their turn within <strong>Range 3</strong> of the drone, it emits a pulse, and they become <strong>Immobilized</strong> until the drone is destroyed.",
+    "tags": [
+      {
+        "id": "tg_drone"
+      },
+      {
+        "id": "tg_limited",
+        "val": 1
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_rotary_grenade_launcher_bastion",
+    "name": "Rotary Grenade Launcher",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "An adjacent allied character can spend a <strong>quick action</strong> to reload this weapon.",
+    "tags": [
+      {
+        "id": "tg_arcing"
+      },
+      {
+        "id": "tg_loading"
+      }
+    ],
+    "weapon_type": "Main Launcher",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Explosive",
         "damage": [
-            {
-                "type": "Kinetic",
-                "damage": [
-                    3,
-                    4,
-                    5
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 1
-            }
-        ],
-        "on_hit": "Target must pass a <strong>Hull</strong> save or be knocked <strong>Prone</strong>."
-    },
-    {
-        "id": "npc-rebake_npcf_friendly_interdiction_bastion",
-        "name": "Friendly Interdiction",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Bastion and one allied character adjacent to it gain <strong>Resistance</strong> to all damage dealt by one character within line of sight. The Bastion may choose a new allied character or a new character to gain <strong>Resistance</strong> from as a <strong>protocol</strong>. The allied character loses <strong>Resistance</strong> if they break adjacency.",
-        "tags": [
-            {
-                "id": "tg_protocol"
-            }
+          4,
+          6,
+          8
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 8
+      },
+      {
+        "type": "Blast",
+        "val": 1
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_heavy_assault_shield_bastion",
+    "name": "Heavy Assault Shield",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_guardian_bastion",
-        "name": "Guardian",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Allied characters can use the Bastion for <strong>hard cover</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_near_threat_denial_system_bastion",
-        "name": "Near-Threat Denial System",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "When characters within <strong>Range 3</strong> attack the Bastion or a character being protected by <strong>Friendly Interdiction</strong>, they take <strong>{2/3/4} AP explosive damage</strong> before rolling.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_siege_guardian_bastion",
-        "name": "Siege Guardian",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Allied characters gain <strong>Resistance</strong> to damage from <strong>Blast</strong>, <strong>Burst</strong>, <strong>Line</strong>, and <strong>Cone</strong> attacks while they’re adjacent to the Bastion.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_fearless_defender_bastion",
-        "name": "Fearless Defender",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Bastion moves to a space adjacent to the triggering character and takes the damage instead. The Bastion may then immediately use <strong>Friendly Interdiction</strong> on the triggering character.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "An allied character in <strong>range 5</strong> of the Bastion takes damage, and the Bastion isn’t <strong>Immobilized</strong>, <strong>Slowed</strong>, <strong>Stunned</strong> or otherwise cannot move."
-    },
-    {
-        "id": "npc-rebake_npcf_deathcounter_bastion",
-        "name": "Deathcounter",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Bastion is wreathed in a crackling energy field visible to all characters. The first time the Bastion is successfully hit by a ranged or melee attack each round, all damage is reduced to <strong>0</strong>, after which the field visibly dissipates until the start of the next round.",
-        "tags": [
-            {
-                "id": "tg_shield"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_stack_up_bastion",
-        "name": "Stack Up",
-        "origin": {
-            "type": "Class",
-            "name": "Bastion [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When the Bastion takes its standard move or <strong>Boosts</strong>, an adjacent allied character can choose to move with them, mirroring their movement. This allied character's movement ignores engagement and does not provoke <strong>reactions</strong>. Each allied character can only move a number of spaces this way each round equal to their <strong>Speed</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_chain_axe_berserker",
-        "name": "Chain Axe",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "<strong>On Critical Hit</strong>: Target becomes <strong>Shredded</strong> until the end of their next turn.",
-        "tags": [],
-        "weapon_type": "Heavy Melee",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_knockback",
+        "val": 1
+      }
+    ],
+    "weapon_type": "Heavy Melee",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Kinetic",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    7,
-                    9,
-                    11
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 1
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_stampede_defense_berserker",
-        "name": "Stampede Defense",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Berserker has <strong>Resistance</strong> to all damage unless they are <strong>Impaired</strong>, <strong>Stunned</strong>, <strong>Immobilized</strong>, <strong>Shredded</strong>, <strong>Slowed</strong> or <strong>Exposed</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_aggression_berserker",
-        "name": "Aggression",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "After taking damage for the first time each round, the Berserker must immediately attack a random adjacent character, hostile or allied, with the <strong>Chain Axe</strong>. This attack happens even if the Berserker is reduced to <strong>0 HP</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_avalanche_charge_berserker",
-        "name": "Avalanche Charge",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Berserker moves spaces equal to their <strong>Speed</strong> in a straight line, ignoring reactions and engagement, then attacks a random adjacent character – hostile or allied — with the <strong>Chain Axe</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
+          3,
+          4,
+          5
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "on_hit": "Target must pass a <strong>Hull</strong> save or be knocked <strong>Prone</strong>."
+  },
+  {
+    "id": "npc-rebake_npcf_friendly_interdiction_bastion",
+    "name": "Friendly Interdiction",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_juggernaut_berserker",
-        "name": "Juggernaut",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When the Berserker uses <strong>Avalanche Charge</strong>, all characters adjacent to the path they follow or adjacent to their final position – hostile and allied – must succeed on a <strong>Hull</strong> save or be knocked <strong>Prone</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Bastion and one allied character adjacent to it gain <strong>Resistance</strong> to all damage dealt by one character within line of sight. The Bastion may choose a new allied character or a new character to gain <strong>Resistance</strong> from as a <strong>protocol</strong>. The allied character loses <strong>Resistance</strong> if they break adjacency.",
+    "tags": [
+      {
+        "id": "tg_protocol"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_guardian_bastion",
+    "name": "Guardian",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_harpoon_cannon_berserker",
-        "name": "Harpoon Cannon",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [],
-        "weapon_type": "Main CQB",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+    "locked": false,
+    "type": "Trait",
+    "effect": "Allied characters can use the Bastion for <strong>hard cover</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_near_threat_denial_system_bastion",
+    "name": "Near-Threat Denial System",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "When characters within <strong>Range 3</strong> attack the Bastion or a character being protected by <strong>Friendly Interdiction</strong>, they take <strong>{2/3/4} AP explosive damage</strong> before rolling.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_siege_guardian_bastion",
+    "name": "Siege Guardian",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "Allied characters gain <strong>Resistance</strong> to damage from <strong>Blast</strong>, <strong>Burst</strong>, <strong>Line</strong>, and <strong>Cone</strong> attacks while they’re adjacent to the Bastion.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_fearless_defender_bastion",
+    "name": "Fearless Defender",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Bastion moves to a space adjacent to the triggering character and takes the damage instead. The Bastion may then immediately use <strong>Friendly Interdiction</strong> on the triggering character.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "An allied character in <strong>range 5</strong> of the Bastion takes damage, and the Bastion isn’t <strong>Immobilized</strong>, <strong>Slowed</strong>, <strong>Stunned</strong> or otherwise cannot move."
+  },
+  {
+    "id": "npc-rebake_npcf_deathcounter_bastion",
+    "name": "Deathcounter",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Bastion is wreathed in a crackling energy field visible to all characters. The first time the Bastion is successfully hit by a ranged or melee attack each round, all damage is reduced to <strong>0</strong>, after which the field visibly dissipates until the start of the next round.",
+    "tags": [
+      {
+        "id": "tg_shield"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_stack_up_bastion",
+    "name": "Stack Up",
+    "origin": {
+      "type": "Class",
+      "name": "Bastion [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "When the Bastion takes its standard move or <strong>Boosts</strong>, an adjacent allied character can choose to move with them, mirroring their movement. This allied character's movement ignores engagement and does not provoke <strong>reactions</strong>. Each allied character can only move a number of spaces this way each round equal to their <strong>Speed</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_chain_axe_berserker",
+    "name": "Chain Axe",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "<strong>On Critical Hit</strong>: Target becomes <strong>Shredded</strong> until the end of their next turn.",
+    "tags": [],
+    "weapon_type": "Heavy Melee",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "Kinetic",
-                "damage": [
-                    2,
-                    3,
-                    4
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 5
-            },
-            {
-                "type": "Threat",
-                "val": 3
-            }
-        ],
-        "on_hit": "Targets of smaller or equal <strong>Size</strong> to the Berserker are pulled adjacent to them in a straight line,or as close as possible. If they’re larger, the Berserker is pulled adjacent to them instead. If this ends with the Berserker adjacent to the target, the Berserker <strong>Grapples</strong> them."
+          7,
+          9,
+          11
+        ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_stampede_defense_berserker",
+    "name": "Stampede Defense",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_retribution_berserker",
-        "name": "Retribution",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Whenever the Berserker takes damage, their next attack deals <strong>+1d6 bonus damage</strong>. This bonus damage is lost when the Berserker attacks, or at the end of their next turn.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Berserker has <strong>Resistance</strong> to all damage unless they are <strong>Impaired</strong>, <strong>Stunned</strong>, <strong>Immobilized</strong>, <strong>Shredded</strong>, <strong>Slowed</strong> or <strong>Exposed</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_aggression_berserker",
+    "name": "Aggression",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_headhunter_berserker",
-        "name": "Headhunter",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Whenever the Berserker attacks a target that is <strong>Grappled</strong>, <strong>Immobilized</strong>, <strong>Stunned</strong>, or <strong>Prone</strong> with the <strong>Chain Axe</strong>, they become <strong>Shredded</strong> on hit rather than on critical hit.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "After taking damage for the first time each round, the Berserker must immediately attack a random adjacent character, hostile or allied, with the <strong>Chain Axe</strong>. This attack happens even if the Berserker is reduced to <strong>0 HP</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_avalanche_charge_berserker",
+    "name": "Avalanche Charge",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_overdrive_servos_berserker",
-        "name": "Overdrive Servos",
-        "origin": {
-            "type": "Class",
-            "name": "Berserker [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Berserker counts as <strong>Size 3</strong> for <strong>Ram</strong> and <strong>Grapple</strong>, and they deal <strong>{3/4/5} kinetic damage</strong> on hit with <strong>Ram</strong> and <strong>Grapple</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Berserker moves spaces equal to their <strong>Speed</strong> in a straight line, ignoring reactions and engagement, then attacks a random adjacent character – hostile or allied — with the <strong>Chain Axe</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_juggernaut_berserker",
+    "name": "Juggernaut",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_bombard_cannon_bombard",
-        "name": "Bombard Cannon",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_arcing"
-            },
-            {
-                "id": "tg_ordnance"
-            }
-        ],
-        "weapon_type": "Superheavy Cannon",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
-        "accuracy": [
-            -1,
-            -1,
-            -1
-        ],
+    "locked": false,
+    "type": "Trait",
+    "effect": "When the Berserker uses <strong>Avalanche Charge</strong>, all characters adjacent to the path they follow or adjacent to their final position – hostile and allied – must succeed on a <strong>Hull</strong> save or be knocked <strong>Prone</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_harpoon_cannon_berserker",
+    "name": "Harpoon Cannon",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [],
+    "weapon_type": "Main CQB",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "Kinetic",
         "damage": [
-            {
-                "type": "Explosive",
-                "damage": [
-                    5,
-                    7,
-                    9
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 25
-            },
-            {
-                "type": "Blast",
-                "val": 2
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_cluster_munitions_bombard",
-        "name": "Cluster Munitions",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Bombard’s attacks deal <strong>{+2/+3/+4} damage</strong> to all characters for each targeted character beyond the first.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_earthshaker_shells_bombard",
-        "name": "Earthshaker Shells",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may also fire a special earthshaker shell. In addition to any damage, all characters within the <strong>Blast</strong> must pass a <strong>Hull</strong> save or be knocked <strong>Prone</strong>. Debris or broken earth is thrown up by the impact, creating two <strong>Size 1</strong> segments of hard cover in free spaces within <strong>Range 5</strong> of the targeted space. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_siege_armor_bombard",
-        "name": "Siege Armor",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Bombard has <strong>Resistance</strong> to all damage from attacks that originate beyond <strong>range 3</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_high_impact_shells_bombard",
-        "name": "High-Impact Shells",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may fire a special high-impact shell. <strong>On hit</strong>, characters are knocked back <strong>3 spaces</strong> either directly away from the Bombard or away from the center of the <strong>Blast</strong>. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack. Only one type of special shell can be fired at a time.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_bunker_buster_bombard",
-        "name": "Bunker Buster",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may fire a special bunker buster shell. The <strong>Bombard Cannon</strong> automatically deals <strong>{10/20/30} AP explosive damage</strong> to all objects and terrain in the affected area, and the area within the <strong>Blast</strong> also becomes <strong>difficult terrain</strong>. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack. Only one type of special shell can be fired at a time.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_flare_drone_bombard",
-        "name": "Flare Drone",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "<strong>Flare Drone</strong> (<strong>Size</strong> 1/2, <strong>HP</strong> {10/20/30}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags</strong>: Drone)<br>This drone can be deployed to a space within line of sight and <strong>Range 25</strong>, where it hovers in place and begins projecting bright light in a <strong>Burst 2</strong> area. All characters in the affected area – including those that move into the affected area or start their turn within it – lose <strong>Invisible</strong> and <strong>Hidden</strong>, and cannot <strong>Hide</strong> or turn <strong>Invisible</strong> within the area. Additionally, the Bombard gains <strong>+1 Accuracy</strong> to attacks against characters within the affected area (including the drone itself). The Bombard can only have one drone deployed at a time; if a new drone is deployed, the old one disintegrates.",
-        "tags": [
-            {
-                "id": "tg_drone"
-            },
-            {
-                "id": "tg_quick_action"
-            }
+          2,
+          3,
+          4
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      },
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "on_hit": "Targets of smaller or equal <strong>Size</strong> to the Berserker are pulled adjacent to them in a straight line,or as close as possible. If they’re larger, the Berserker is pulled adjacent to them instead. If this ends with the Berserker adjacent to the target, the Berserker <strong>Grapples</strong> them."
+  },
+  {
+    "id": "npc-rebake_npcf_retribution_berserker",
+    "name": "Retribution",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_high-angle_fire_bombard",
-        "name": "High-Angle Fire",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Bombard may prepare a delayed, high-angle shot with the <strong>Bombard Cannon</strong>. Choose a <strong>Blast 3</strong> area, which becomes visible to all characters; the Bombard then makes an attack at the end of the next round with the <strong>Bombard Cannon</strong>, after all characters have acted, against every target within the area.",
-        "tags": [
-            {
-                "id": "tg_full_action"
-            },
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "Whenever the Berserker takes damage, their next attack deals <strong>+1d6 bonus damage</strong>. This bonus damage is lost when the Berserker attacks, or at the end of their next turn.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_headhunter_berserker",
+    "name": "Headhunter",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_counterbattery_suite_bombard",
-        "name": "Counterbattery Suite",
-        "origin": {
-            "type": "Class",
-            "name": "Bombard [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The triggering character gains Lock On. This Reaction can't be used against characters within Range 3 of the Bombard.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "A hostile character makes an attack against the Bombard."
+    "locked": false,
+    "type": "Trait",
+    "effect": "Whenever the Berserker attacks a target that is <strong>Grappled</strong>, <strong>Immobilized</strong>, <strong>Stunned</strong>, or <strong>Prone</strong> with the <strong>Chain Axe</strong>, they become <strong>Shredded</strong> on hit rather than on critical hit.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_overdrive_servos_berserker",
+    "name": "Overdrive Servos",
+    "origin": {
+      "type": "Class",
+      "name": "Berserker [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_dual_shotguns_breacher",
-        "name": "Dual Shotguns",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "This weapon can make two attacks at once, targeting either the same character or different ones. The final attack rolls for this weapon can never be affected by <strong>Accuracy</strong>.",
-        "tags": [],
-        "weapon_type": "Main CQB",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
-        "accuracy": [
-            -2,
-            -2,
-            -2
-        ],
+    "locked": false,
+    "type": "System",
+    "effect": "The Berserker counts as <strong>Size 3</strong> for <strong>Ram</strong> and <strong>Grapple</strong>, and they deal <strong>{3/4/5} kinetic damage</strong> on hit with <strong>Ram</strong> and <strong>Grapple</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_bombard_cannon_bombard",
+    "name": "Bombard Cannon",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_arcing"
+      },
+      {
+        "id": "tg_ordnance"
+      }
+    ],
+    "weapon_type": "Superheavy Cannon",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "accuracy": [
+      -1,
+      -1,
+      -1
+    ],
+    "damage": [
+      {
+        "type": "Explosive",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    5,
-                    7,
-                    9
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 3
-            },
-            {
-                "type": "Threat",
-                "val": 3
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_breach_ram_breacher",
-        "name": "Breach Ram",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Breacher moves up to <strong>6 spaces</strong> in a straight line, ignoring engagement and passing through – but not stopping in – spaces occupied by other characters. Obstructions and objects in the Breacher’s path take <strong>10/20/30 AP kinetic damage</strong>. The Breacher passes through any obstructions destroyed this way and continues moving until they have moved <strong>6 spaces</strong> or fail to destroy an obstruction. Any characters in the Breacher’s path must succeed on an <strong>Agility</strong> save or be pushed out of the way as directly as possible and knocked <strong>Prone</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_quick_action"
-            }
+          5,
+          7,
+          9
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 25
+      },
+      {
+        "type": "Blast",
+        "val": 2
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_cluster_munitions_bombard",
+    "name": "Cluster Munitions",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_break_armor_breacher",
-        "name": "Break Armor",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Characters that are successfully attacked more than once in a turn by the Breacher’s <strong>Dual Shotguns</strong> become <strong>Shredded</strong> for the rest of the scene.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Bombard’s attacks deal <strong>{+2/+3/+4} damage</strong> to all characters for each targeted character beyond the first.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_earthshaker_shells_bombard",
+    "name": "Earthshaker Shells",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_ram_plating_breacher",
-        "name": "Ram Plating",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Breacher gains <strong>+1 Accuracy</strong> to Ram.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may also fire a special earthshaker shell. In addition to any damage, all characters within the <strong>Blast</strong> must pass a <strong>Hull</strong> save or be knocked <strong>Prone</strong>. Debris or broken earth is thrown up by the impact, creating two <strong>Size 1</strong> segments of hard cover in free spaces within <strong>Range 5</strong> of the targeted space. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_siege_armor_bombard",
+    "name": "Siege Armor",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_follower_count_breacher",
-        "name": "Follower Count",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Breacher makes a tech attack against a character within <strong>Sensors</strong>. On a success, the Breacher gains <strong>+1 Accuracy</strong> on all attacks against their target, and may <strong>Boost</strong> once per turn as a <strong>free action</strong> so long as it moves them directly towards their target. This lasts until either character is destroyed and cannot be changed to a new target unless the Breacher takes <strong>4 Heat</strong> to attempt this tech attack against a different target.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Bombard has <strong>Resistance</strong> to all damage from attacks that originate beyond <strong>range 3</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_high_impact_shells_bombard",
+    "name": "High-Impact Shells",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_thermal_charge_breacher",
-        "name": "Thermal Charge",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Breacher may expend a charge to throw a grenade to a space within <strong>Range 5</strong>. Characters in the ensuing <strong>Blast 1</strong> explosion must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and become <strong>Shredded</strong> until the end of their next turn. Objects, terrain, and <strong>Deployables</strong> in the area automatically take <strong>{10/20/30} AP explosive damage</strong>; if any objects or terrain are destroyed this way, the Breacher may immediately move their <strong>Speed</strong> towards one of those spaces or as close as possible.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_grenade"
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may fire a special high-impact shell. <strong>On hit</strong>, characters are knocked back <strong>3 spaces</strong> either directly away from the Bombard or away from the center of the <strong>Blast</strong>. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack. Only one type of special shell can be fired at a time.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_bunker_buster_bombard",
+    "name": "Bunker Buster",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_painmaker_breacher",
-        "name": "Painmaker",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Breacher prepares a salvo of shells, becoming <strong>Slowed</strong> until the end of their next turn. This effect is visible to everyone. During the Breacher's next turn, the next time they use the <strong>Dual Shotguns</strong>, they may make four attacks at once instead of two.",
-        "tags": [
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may fire a special bunker buster shell. The <strong>Bombard Cannon</strong> automatically deals <strong>{10/20/30} AP explosive damage</strong> to all objects and terrain in the affected area, and the area within the <strong>Blast</strong> also becomes <strong>difficult terrain</strong>. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack. Only one type of special shell can be fired at a time.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_flare_drone_bombard",
+    "name": "Flare Drone",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_fragmentation_shells_breacher",
-        "name": "Fragmentation Shells",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "<strong>1/round</strong>, when the Breacher makes a successful attack with the <strong>Dual Shotguns</strong>, a different character within <strong>Range 3</strong> of the target takes <strong>{2/3/4} kinetic damage</strong> + bonus damage equal to the initial target's <strong>Armor</strong>.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "<strong>Flare Drone</strong> (<strong>Size</strong> 1/2, <strong>HP</strong> {10/20/30}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags</strong>: Drone)<br>This drone can be deployed to a space within line of sight and <strong>Range 25</strong>, where it hovers in place and begins projecting bright light in a <strong>Burst 2</strong> area. All characters in the affected area – including those that move into the affected area or start their turn within it – lose <strong>Invisible</strong> and <strong>Hidden</strong>, and cannot <strong>Hide</strong> or turn <strong>Invisible</strong> within the area. Additionally, the Bombard gains <strong>+1 Accuracy</strong> to attacks against characters within the affected area (including the drone itself). The Bombard can only have one drone deployed at a time; if a new drone is deployed, the old one disintegrates.",
+    "tags": [
+      {
+        "id": "tg_drone"
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_high-angle_fire_bombard",
+    "name": "High-Angle Fire",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_breach_and_clear_breacher",
-        "name": "Breach and Clear",
-        "origin": {
-            "type": "Class",
-            "name": "Breacher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When using <strong>Breach Ram</strong>, the Breacher may also attack any character in their path with the <strong>Dual Shotguns</strong>. The <strong>Dual Shotguns</strong> only make a single attack against each character this way (rather than making two attacks at once), and these attacks deal half damage on hit.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Bombard may prepare a delayed, high-angle shot with the <strong>Bombard Cannon</strong>. Choose a <strong>Blast 3</strong> area, which becomes visible to all characters; the Bombard then makes an attack at the end of the next round with the <strong>Bombard Cannon</strong>, after all characters have acted, against every target within the area.",
+    "tags": [
+      {
+        "id": "tg_full_action"
+      },
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_counterbattery_suite_bombard",
+    "name": "Counterbattery Suite",
+    "origin": {
+      "type": "Class",
+      "name": "Bombard [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_ram_cannon_cataphract",
-        "name": "Ram Cannon",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "This lance can be used as either a ranged or melee weapon, but not both in the same turn. When used as a ranged weapon, <strong>Critical Hits</strong> cause the target to become <strong>Impaired</strong> until the end of their next turn. When used as a melee weapon, it gains <strong>Knockback 2</strong>.",
-        "tags": [],
-        "weapon_type": "Heavy Melee/Heavy Cannon",
-        "attack_bonus": [
-            0,
-            0,
-            0
-        ],
-        "accuracy": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The triggering character gains Lock On. This Reaction can't be used against characters within Range 3 of the Bombard.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "A hostile character makes an attack against the Bombard."
+  },
+  {
+    "id": "npc-rebake_npcf_dual_shotguns_breacher",
+    "name": "Dual Shotguns",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "This weapon can make two attacks at once, targeting either the same character or different ones. The final attack rolls for this weapon can never be affected by <strong>Accuracy</strong>.",
+    "tags": [],
+    "weapon_type": "Main CQB",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "accuracy": [
+      -2,
+      -2,
+      -2
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    5,
-                    7,
-                    9
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 5
-            },
-            {
-                "type": "Threat",
-                "val": 2
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_trample_cataphract",
-        "name": "Trample",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Cataphract ignores engagement and can pass through – but not stop in – spaces occupied by other characters, 1/turn dealing <strong>{2/3/4} kinetic damage</strong> to those characters.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_impale_cataphract",
-        "name": "Impale",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Cataphract moves up to <strong>8 spaces</strong> in a straight line. Pick a character that the Cataphract passed through or ended adjacent to; they must pass a <strong>Hull</strong> save. On a failure, they are <strong>grappled</strong> by the Cataphract and pulled with the Cataphract to the end of their movement. On <strong>Critical Hit</strong> with the <strong>Ram Cannon</strong>, this system automatically <strong>Recharges</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_action"
-            }
+          5,
+          7,
+          9
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 3
+      },
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_breach_ram_breacher",
+    "name": "Breach Ram",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_point_defense_shield_cataphract",
-        "name": "Point-Defense Shield",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Cataphract has <strong>Resistance</strong> to all damage from the closest hostile character. If multiple characters are equally close, this effect does not apply.",
-        "tags": [
-            {
-                "id": "tg_shield"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Breacher moves up to <strong>6 spaces</strong> in a straight line, ignoring engagement and passing through – but not stopping in – spaces occupied by other characters. Obstructions and objects in the Breacher’s path take <strong>10/20/30 AP kinetic damage</strong>. The Breacher passes through any obstructions destroyed this way and continues moving until they have moved <strong>6 spaces</strong> or fail to destroy an obstruction. Any characters in the Breacher’s path must succeed on an <strong>Agility</strong> save or be pushed out of the way as directly as possible and knocked <strong>Prone</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_break_armor_breacher",
+    "name": "Break Armor",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_electrified_lasso_cataphract",
-        "name": "Electrified Lasso",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "A character in line of sight and <strong>Range 5</strong> must make a <strong>Hull</strong> save. On a failure, they take {2/3/4} Heat and are pulled as close as possible to the Cataphract; if they become adjacent, the Cataphract automatically grapples them.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "Characters that are successfully attacked more than once in a turn by the Breacher’s <strong>Dual Shotguns</strong> become <strong>Shredded</strong> for the rest of the scene.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_ram_plating_breacher",
+    "name": "Ram Plating",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_lance_shot_cataphract",
-        "name": "Lance Shot",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Cataphract fires a piercing lance in a <strong>Line 5</strong> path. All characters within the affected area must pass a <strong>Hull</strong> save or be knocked back <strong>3 spaces</strong>. Any character that collides with an obstruction or another character also becomes <strong>Immobilized</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Breacher gains <strong>+1 Accuracy</strong> to Ram.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_follower_count_breacher",
+    "name": "Follower Count",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_electromagnetic_bola_cataphract",
-        "name": "Electromagnetic Bola",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "A flying character in <strong>Range 10</strong> must pass an Agility save. On a failure, they are pulled <strong>3 spaces</strong>, land immediately, and become <strong>Immobilized</strong> until the end of their next turn. This counts as falling but without damage.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Breacher makes a tech attack against a character within <strong>Sensors</strong>. On a success, the Breacher gains <strong>+1 Accuracy</strong> on all attacks against their target, and may <strong>Boost</strong> once per turn as a <strong>free action</strong> so long as it moves them directly towards their target. This lasts until either character is destroyed and cannot be changed to a new target unless the Breacher takes <strong>4 Heat</strong> to attempt this tech attack against a different target.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_thermal_charge_breacher",
+    "name": "Thermal Charge",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_charge_cataphract",
-        "name": "Charge",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Cataphract moves spaces equal to their <strong>Speed</strong> in a straight line, ignoring <strong>reactions</strong> and engagement, then attacks a target within <strong>Range</strong> with the <strong>Ram Cannon</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Breacher may expend a charge to throw a grenade to a space within <strong>Range 5</strong>. Characters in the ensuing <strong>Blast 1</strong> explosion must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and become <strong>Shredded</strong> until the end of their next turn. Objects, terrain, and <strong>Deployables</strong> in the area automatically take <strong>{10/20/30} AP explosive damage</strong>; if any objects or terrain are destroyed this way, the Breacher may immediately move their <strong>Speed</strong> towards one of those spaces or as close as possible.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_grenade"
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_painmaker_breacher",
+    "name": "Painmaker",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_capacitor_discharge_cataphract",
-        "name": "Capacitor Discharge",
-        "origin": {
-            "type": "Class",
-            "name": "Cataphract [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "As long as the Cataphract isn't <strong>Slowed</strong> or <strong>Jammed</strong>, whenever characters make melee attacks against them, they take <strong>{2/3/4} Heat</strong> before rolling.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Breacher prepares a salvo of shells, becoming <strong>Slowed</strong> until the end of their next turn. This effect is visible to everyone. During the Breacher's next turn, the next time they use the <strong>Dual Shotguns</strong>, they may make four attacks at once instead of two.",
+    "tags": [
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_fragmentation_shells_breacher",
+    "name": "Fragmentation Shells",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_demolition_hammer_demolisher",
-        "name": "Demolition Hammer",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_ap"
-            },
-            {
-                "id": "tg_knockback",
-                "val": 3
-            }
-        ],
-        "weapon_type": "Superheavy Melee",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
-        "accuracy": [
-            -1,
-            -1,
-            -1
-        ],
+    "locked": false,
+    "type": "Trait",
+    "effect": "<strong>1/round</strong>, when the Breacher makes a successful attack with the <strong>Dual Shotguns</strong>, a different character within <strong>Range 3</strong> of the target takes <strong>{2/3/4} kinetic damage</strong> + bonus damage equal to the initial target's <strong>Armor</strong>.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_breach_and_clear_breacher",
+    "name": "Breach and Clear",
+    "origin": {
+      "type": "Class",
+      "name": "Breacher [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "When using <strong>Breach Ram</strong>, the Breacher may also attack any character in their path with the <strong>Dual Shotguns</strong>. The <strong>Dual Shotguns</strong> only make a single attack against each character this way (rather than making two attacks at once), and these attacks deal half damage on hit.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_ram_cannon_cataphract",
+    "name": "Ram Cannon",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "This lance can be used as either a ranged or melee weapon, but not both in the same turn. When used as a ranged weapon, <strong>Critical Hits</strong> cause the target to become <strong>Impaired</strong> until the end of their next turn. When used as a melee weapon, it gains <strong>Knockback 2</strong>.",
+    "tags": [],
+    "weapon_type": "Heavy Melee/Heavy Cannon",
+    "attack_bonus": [
+      0,
+      0,
+      0
+    ],
+    "accuracy": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "Explosive",
-                "damage": [
-                    12,
-                    14,
-                    16
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 2
-            }
-        ],
-        "on_hit": "Targets must succeed on a <strong>Hull</strong> save or be <strong>Stunned</strong> until the end of their next turn."
+          5,
+          7,
+          9
+        ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      },
+      {
+        "type": "Threat",
+        "val": 2
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_trample_cataphract",
+    "name": "Trample",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_earthshatter_demolisher",
-        "name": "Earthshatter",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "<strong>On Attack</strong>: The Demolisher deals <strong>10/20/30 AP kinetic damage</strong> to an object or piece of terrain within <strong>Range 2</strong>, if there is one. Hit or miss, place a <strong>Size 1</strong> piece of terrain that grants <strong>hard cover</strong> in a free space adjacent to your target. The terrain has <strong>10 HP</strong> and <strong>Evasion 5</strong>.",
-        "tags": [
-            {
-                "id": "tg_thrown",
-                "val": 5
-            },
-            {
-                "id": "tg_knockback",
-                "val": 3
-            }
-        ],
-        "weapon_type": "Heavy Melee",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Cataphract ignores engagement and can pass through – but not stop in – spaces occupied by other characters, 1/turn dealing <strong>{2/3/4} kinetic damage</strong> to those characters.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_impale_cataphract",
+    "name": "Impale",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Cataphract moves up to <strong>8 spaces</strong> in a straight line. Pick a character that the Cataphract passed through or ended adjacent to; they must pass a <strong>Hull</strong> save. On a failure, they are <strong>grappled</strong> by the Cataphract and pulled with the Cataphract to the end of their movement. On <strong>Critical Hit</strong> with the <strong>Ram Cannon</strong>, this system automatically <strong>Recharges</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_point_defense_shield_cataphract",
+    "name": "Point-Defense Shield",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Cataphract has <strong>Resistance</strong> to all damage from the closest hostile character. If multiple characters are equally close, this effect does not apply.",
+    "tags": [
+      {
+        "id": "tg_shield"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_electrified_lasso_cataphract",
+    "name": "Electrified Lasso",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "A character in line of sight and <strong>Range 5</strong> must make a <strong>Hull</strong> save. On a failure, they take {2/3/4} Heat and are pulled as close as possible to the Cataphract; if they become adjacent, the Cataphract automatically grapples them.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_lance_shot_cataphract",
+    "name": "Lance Shot",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Cataphract fires a piercing lance in a <strong>Line 5</strong> path. All characters within the affected area must pass a <strong>Hull</strong> save or be knocked back <strong>3 spaces</strong>. Any character that collides with an obstruction or another character also becomes <strong>Immobilized</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_electromagnetic_bola_cataphract",
+    "name": "Electromagnetic Bola",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "A flying character in <strong>Range 10</strong> must pass an Agility save. On a failure, they are pulled <strong>3 spaces</strong>, land immediately, and become <strong>Immobilized</strong> until the end of their next turn. This counts as falling but without damage.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_charge_cataphract",
+    "name": "Charge",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Cataphract moves spaces equal to their <strong>Speed</strong> in a straight line, ignoring <strong>reactions</strong> and engagement, then attacks a target within <strong>Range</strong> with the <strong>Ram Cannon</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_capacitor_discharge_cataphract",
+    "name": "Capacitor Discharge",
+    "origin": {
+      "type": "Class",
+      "name": "Cataphract [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "As long as the Cataphract isn't <strong>Slowed</strong> or <strong>Jammed</strong>, whenever characters make melee attacks against them, they take <strong>{2/3/4} Heat</strong> before rolling.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_demolition_hammer_demolisher",
+    "name": "Demolition Hammer",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_ap"
+      },
+      {
+        "id": "tg_knockback",
+        "val": 3
+      }
+    ],
+    "weapon_type": "Superheavy Melee",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "accuracy": [
+      -1,
+      -1,
+      -1
+    ],
+    "damage": [
+      {
+        "type": "Explosive",
         "damage": [
-            {
-                "type": "Kinetic",
-                "damage": [
-                    5,
-                    6,
-                    7
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 2
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_shock_armor_demolisher",
-        "name": "Shock Armor",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Demolisher has <strong>Resistance to damage from melee weapons</strong>.",
-        "resistance": [
-            "Melee"
-        ],
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_heavy_frame_demolisher",
-        "name": "Heavy Frame",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Demolisher can’t be pushed, pulled, knocked <strong>Prone</strong>, or knocked back by smaller characters.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_jet_propulsion_demolisher",
-        "name": "Jet Propulsion",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "Whenever the Demolisher makes an attack with the <strong>Demolition Hammer</strong>, it may take <strong>4 Heat</strong> to move <strong>4 spaces</strong> in a straight line directly towards the target before the attack.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_kinetic_compensation_demolisher",
-        "name": "Kinetic Compensation",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Each time the Demolisher misses with the <strong>Demolition Hammer</strong>, they gain <strong>+1 Accuracy</strong> on all subsequent attacks with it until they hit. This <strong>Accuracy</strong> can be gained multiple times and stacks.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_seismic_destroyer_demolisher",
-        "name": "Seismic Destroyer",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "Unless they can fly, all characters in a <strong>Cone 5</strong> area pass an <strong>Agility</strong> save or be knocked <strong>Prone</strong>. All objects and terrain within this area takes <strong>{10/20/30} AP kinetic damage</strong>; if any terrain or objects are destroyed this way, all affected characters also automatically take <strong>{4/6/8} kinetic damage</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_action"
-            }
+          12,
+          14,
+          16
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 2
+      }
+    ],
+    "on_hit": "Targets must succeed on a <strong>Hull</strong> save or be <strong>Stunned</strong> until the end of their next turn."
+  },
+  {
+    "id": "npc-rebake_npcf_earthshatter_demolisher",
+    "name": "Earthshatter",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_hullcracker_demolisher",
-        "name": "Hullcracker",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Demolisher chooses a character within <strong>Range 2</strong>: they must pass a <strong>Hull</strong> save or be <strong>Immobilized</strong> and <strong>Shredded</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_drag_cables_demolisher",
-        "name": "Drag Cables",
-        "origin": {
-            "type": "Class",
-            "name": "Demolisher [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Demolisher chooses a character within <strong>Range 5</strong>; that character must pass a <strong>Hull</strong> save or become embedded with high-tensile cable anchors. If the target is Stunned, they automatically fail this save. While these anchors are embedded, neither the target nor the Demolisher can move more than <strong>5 spaces</strong> away from one another. If the target is smaller than the Demolisher, they move when the Demolisher moves, mirroring their movements. The Demolisher can activate this system again and force an embedded character to pass another <strong>Hull</strong> save or be pulled adjacent to the Demolisher.<br>An embedded character can remove the cables on a hit with a <strong>melee attack</strong> against <strong>Evasion 10</strong>. Otherwise, this effect lasts until the end of the scene, until either character is destroyed, or until the Demolisher uses this system on a new target.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_flak_cannon_engineer",
-        "name": "Flak Cannon",
-        "origin": {
-            "type": "Class",
-            "name": "Engineer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "This weapon gains <strong>+1 Accuracy</strong> against <strong>flying</strong> targets.",
-        "tags": [
-            {
-                "id": "tg_smart"
-            }
-        ],
-        "weapon_type": "Heavy Cannon",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "effect": "<strong>On Attack</strong>: The Demolisher deals <strong>10/20/30 AP kinetic damage</strong> to an object or piece of terrain within <strong>Range 2</strong>, if there is one. Hit or miss, place a <strong>Size 1</strong> piece of terrain that grants <strong>hard cover</strong> in a free space adjacent to your target. The terrain has <strong>10 HP</strong> and <strong>Evasion 5</strong>.",
+    "tags": [
+      {
+        "id": "tg_thrown",
+        "val": 5
+      },
+      {
+        "id": "tg_knockback",
+        "val": 3
+      }
+    ],
+    "weapon_type": "Heavy Melee",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Kinetic",
         "damage": [
-            {
-                "type": "Explosive",
-                "damage": [
-                    3,
-                    4,
-                    5
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 15
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_deployable_turret_engineer",
-        "name": "Deployable Turret",
-        "origin": {
-            "type": "Class",
-            "name": "Engineer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "Deployable Turret (<strong>Size</strong> 1/2, <strong>HP</strong> {1/1/1}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags:</strong> Drone)<br>Up to two of these self-constructing turrets can be deployed to any free space within <strong>Range 3</strong>. At the end of Engineer’s turn, deployed turrets attack the nearest hostile character within <strong>Range 10</strong>. They attack at +{1/2/3} and deal <strong>{4/5/6} Kinetic damage</strong>. The Engineer may have six turrets deployed at one time; if they deploy additional turrets beyond this, previous turrets of their choice are destroyed until they have no more than six total.<br>All turrets are destroyed when the Engineer is destroyed. If the Engineer becomes <strong>Jammed</strong> or <strong>Stunned</strong>, their turrets are also disabled for the duration of those conditions.",
-        "tags": [
-            {
-                "id": "tg_drone"
-            },
-            {
-                "id": "tg_quick_action"
-            }
+          5,
+          6,
+          7
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 2
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_shock_armor_demolisher",
+    "name": "Shock Armor",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_target_designator_engineer",
-        "name": "Target Designator",
-        "origin": {
-            "type": "Class",
-            "name": "Engineer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Engineer chooses a character within line of sight and <strong>Sensors</strong>; they gain <strong>Lock On</strong>. At the end of the Engineer's turn, up to two of their <strong>Deployable Turrets</strong> will attack that target (if it is within range) instead of attacking the nearest hostile character.<br>This trait automatically <strong>recharges</strong> whenever two or more <strong>Deployable Turrets</strong> are destroyed by hostile characters before the end of the Engineer's next turn.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Demolisher has <strong>Resistance to damage from melee weapons</strong>.",
+    "resistance": [
+      "Melee"
+    ],
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_heavy_frame_demolisher",
+    "name": "Heavy Frame",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_deployable_fortifications_engineer",
-        "name": "Deployable Fortifications",
-        "origin": {
-            "type": "Class",
-            "name": "Engineer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "<strong>Deployable Turrets</strong> are <strong>Size 1</strong>, and adjacent allied characters can use them for <strong>hard cover</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Demolisher can’t be pushed, pulled, knocked <strong>Prone</strong>, or knocked back by smaller characters.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_jet_propulsion_demolisher",
+    "name": "Jet Propulsion",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_perimeter_defense_engineer",
-        "name": "Perimiter Defense",
-        "origin": {
-            "type": "Class",
-            "name": "Engineer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "<strong>Deployable Turrets</strong> gain <strong>Threat 3</strong> and can <strong>Overwatch</strong> (1/round per turret), and the Engineer gains the <strong>Auto-Tracking</strong> reaction.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "Whenever the Demolisher makes an attack with the <strong>Demolition Hammer</strong>, it may take <strong>4 Heat</strong> to move <strong>4 spaces</strong> in a straight line directly towards the target before the attack.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_kinetic_compensation_demolisher",
+    "name": "Kinetic Compensation",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_auto_tracking_engineer",
-        "name": "Auto-Tracking",
-        "origin": {
-            "type": "Reaction",
-            "name": "Engineer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The <strong>Deployable Turret</strong> makes an attack against the triggering character's target, as long as the target is within line of sight and <strong>Range</strong>.",
-        "tags": [],
-        "trigger": "An allied character within <strong>Range 3</strong> of a <strong>Deployable Turret</strong> makes a successful attack."
+    "locked": false,
+    "type": "Trait",
+    "effect": "Each time the Demolisher misses with the <strong>Demolition Hammer</strong>, they gain <strong>+1 Accuracy</strong> on all subsequent attacks with it until they hit. This <strong>Accuracy</strong> can be gained multiple times and stacks.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_seismic_destroyer_demolisher",
+    "name": "Seismic Destroyer",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_mobile_turrets_engineer",
-        "name": "Mobile Turrets",
-        "origin": {
-            "type": "Class",
-            "name": "Engineer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "At the start of the Engineer’s turn, they may move two <strong>Deployable Turrets</strong> up to <strong>3 spaces</strong> in any direction.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "Unless they can fly, all characters in a <strong>Cone 5</strong> area pass an <strong>Agility</strong> save or be knocked <strong>Prone</strong>. All objects and terrain within this area takes <strong>{10/20/30} AP kinetic damage</strong>; if any terrain or objects are destroyed this way, all affected characters also automatically take <strong>{4/6/8} kinetic damage</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_hullcracker_demolisher",
+    "name": "Hullcracker",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_skyshield_protocol_engineer",
-        "name": "Skyshield Protocol",
-        "origin": {
-            "type": "Class",
-            "name": "Engineer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Deployable Turrets gain <strong>+1 Accuracy</strong> against <strong>flying</strong> targets.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "The Demolisher chooses a character within <strong>Range 2</strong>: they must pass a <strong>Hull</strong> save or be <strong>Immobilized</strong> and <strong>Shredded</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_drag_cables_demolisher",
+    "name": "Drag Cables",
+    "origin": {
+      "type": "Class",
+      "name": "Demolisher [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_repurpose_engineer",
-        "name": "Repurpose",
-        "origin": {
-            "type": "Class",
-            "name": "Engineer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Engineer chooses an allied character adjacent to one of their <strong>Deployable Turrets</strong>; that character either gains {3/4/5} <strong>Overshield</strong> or gains <strong>+1 Accuracy</strong> on all attacks, checks and saves until the end of their next turn. The turret is then destroyed.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Demolisher chooses a character within <strong>Range 5</strong>; that character must pass a <strong>Hull</strong> save or become embedded with high-tensile cable anchors. If the target is Stunned, they automatically fail this save. While these anchors are embedded, neither the target nor the Demolisher can move more than <strong>5 spaces</strong> away from one another. If the target is smaller than the Demolisher, they move when the Demolisher moves, mirroring their movements. The Demolisher can activate this system again and force an embedded character to pass another <strong>Hull</strong> save or be pulled adjacent to the Demolisher.<br>An embedded character can remove the cables on a hit with a <strong>melee attack</strong> against <strong>Evasion 10</strong>. Otherwise, this effect lasts until the end of the scene, until either character is destroyed, or until the Demolisher uses this system on a new target.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_flak_cannon_engineer",
+    "name": "Flak Cannon",
+    "origin": {
+      "type": "Class",
+      "name": "Engineer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_drum_shotgun_goliath",
-        "name": "Drum Shotgun",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "This weapon ignores ranged penalties from <strong>Engaged</strong>.",
-        "tags": [],
-        "weapon_type": "Heavy CQB",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "effect": "This weapon gains <strong>+1 Accuracy</strong> against <strong>flying</strong> targets.",
+    "tags": [
+      {
+        "id": "tg_smart"
+      }
+    ],
+    "weapon_type": "Heavy Cannon",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Explosive",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    5,
-                    6,
-                    7
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 5
-            },
-            {
-                "type": "Threat",
-                "val": 3
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_crush_targeting_goliath",
-        "name": "Crush Targeting",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "A hostile character within Sensors and line of sight gains <strong>+3 Difficulty</strong> to attack against any character other than the Goliath until the start of the Goliath’s next turn. This effect does not stack, and the effect ends immediately if the Goliath becomes <strong>Jammed</strong> or <strong>Stunned</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            }
-        ],
-        "tech_type": "Quick"
-    },
-    {
-        "id": "npc-rebake_npcf_towering_stride_goliath",
-        "name": "Towering Stride",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Goliath can end its turn overlapping obstructions, cover, and terrain smaller than <strong>Size 3</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_heavy_frame_goliath",
-        "name": "Heavy Frame",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Goliath can’t be pushed, pulled, knocked <strong>Prone</strong>, or knocked back by smaller characters.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_guardian_goliath",
-        "name": "Guardian",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Adjacent allied characters can use the Goliath for <strong>hard cover</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_power_knuckle_goliath",
-        "name": "Power Knuckle",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "A character within <strong>Range 2</strong> must pass a <strong>Hull</strong> save or take <strong>{4/5/6} Kinetic damage</strong>, be pushed <strong>5 spaces</strong> directly away from the Goliath, and knocked <strong>Prone</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
+          3,
+          4,
+          5
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_deployable_turret_engineer",
+    "name": "Deployable Turret",
+    "origin": {
+      "type": "Class",
+      "name": "Engineer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_pin_goliath",
-        "name": "Pin",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "A character within <strong>Range 2</strong> becomes <strong>Immobilized</strong> and <strong>Impaired</strong> until they either damage the Goliath, the Goliath is <strong>Stunned</strong> or destroyed, or the Goliath targets another character with this effect. The Goliath is <strong>Immobilized</strong> for the duration of this effect.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "Deployable Turret (<strong>Size</strong> 1/2, <strong>HP</strong> {1/1/1}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags:</strong> Drone)<br>Up to two of these self-constructing turrets can be deployed to any free space within <strong>Range 3</strong>. At the end of Engineer’s turn, deployed turrets attack the nearest hostile character within <strong>Range 10</strong>. They attack at +{1/2/3} and deal <strong>{4/5/6} Kinetic damage</strong>. The Engineer may have six turrets deployed at one time; if they deploy additional turrets beyond this, previous turrets of their choice are destroyed until they have no more than six total.<br>All turrets are destroyed when the Engineer is destroyed. If the Engineer becomes <strong>Jammed</strong> or <strong>Stunned</strong>, their turrets are also disabled for the duration of those conditions.",
+    "tags": [
+      {
+        "id": "tg_drone"
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_target_designator_engineer",
+    "name": "Target Designator",
+    "origin": {
+      "type": "Class",
+      "name": "Engineer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_mag_gauntlet_goliath",
-        "name": "Mag Gauntlet",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "A character within <strong>Sensors</strong> and line of sight must pass a <strong>Hull</strong> save or be pulled <strong>3 spaces</strong> towards the Goliath. If they are pulled adjacent to the Goliath, they automatically become grappled. The Goliath can only grapple one character this way at a time, and can't use this system while grappling someone this way.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Engineer chooses a character within line of sight and <strong>Sensors</strong>; they gain <strong>Lock On</strong>. At the end of the Engineer's turn, up to two of their <strong>Deployable Turrets</strong> will attack that target (if it is within range) instead of attacking the nearest hostile character.<br>This trait automatically <strong>recharges</strong> whenever two or more <strong>Deployable Turrets</strong> are destroyed by hostile characters before the end of the Engineer's next turn.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_deployable_fortifications_engineer",
+    "name": "Deployable Fortifications",
+    "origin": {
+      "type": "Class",
+      "name": "Engineer [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_coercive_force_goliath",
-        "name": "Coercive Force",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "All characters of the Goliath's choice within <strong>Sensors</strong> are pulled <strong>2 spaces</strong> towards the Goliath.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_tech"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "<strong>Deployable Turrets</strong> are <strong>Size 1</strong>, and adjacent allied characters can use them for <strong>hard cover</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_perimeter_defense_engineer",
+    "name": "Perimiter Defense",
+    "origin": {
+      "type": "Class",
+      "name": "Engineer [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_attractor_field_goliath",
-        "name": "Attractor Field",
-        "origin": {
-            "type": "Class",
-            "name": "Goliath [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Goliath becomes the target of the attack instead. If the attack was an area of effect, such as a <strong>Line</strong>, <strong>Cone</strong>, <strong>Blast</strong>, etc, the attacker must now position it so it targets the Goliath, or as close as possible, which could change its targets. This transfer takes place even if the attack could not have hit the Goliath (i.e. it was a melee attack).",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "An allied character within <strong>Range 2</strong> and line of sight is targeted by an attack dealing <strong>kinetic</strong> or <strong>explosive</strong> damage."
+    "locked": false,
+    "type": "Trait",
+    "effect": "<strong>Deployable Turrets</strong> gain <strong>Threat 3</strong> and can <strong>Overwatch</strong> (1/round per turret), and the Engineer gains the <strong>Auto-Tracking</strong> reaction.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_auto_tracking_engineer",
+    "name": "Auto-Tracking",
+    "origin": {
+      "type": "Reaction",
+      "name": "Engineer [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_hunter_killer_nexus_hive",
-        "name": "Hunter-Killer Nexus",
-        "origin": {
-            "type": "Class",
-            "name": "Hive [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_smart"
-            },
-            {
-                "id": "tg_seeking"
-            }
-        ],
-        "weapon_type": "Main Nexus",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The <strong>Deployable Turret</strong> makes an attack against the triggering character's target, as long as the target is within line of sight and <strong>Range</strong>.",
+    "tags": [],
+    "trigger": "An allied character within <strong>Range 3</strong> of a <strong>Deployable Turret</strong> makes a successful attack."
+  },
+  {
+    "id": "npc-rebake_npcf_mobile_turrets_engineer",
+    "name": "Mobile Turrets",
+    "origin": {
+      "type": "Class",
+      "name": "Engineer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "At the start of the Engineer’s turn, they may move two <strong>Deployable Turrets</strong> up to <strong>3 spaces</strong> in any direction.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_skyshield_protocol_engineer",
+    "name": "Skyshield Protocol",
+    "origin": {
+      "type": "Class",
+      "name": "Engineer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "Deployable Turrets gain <strong>+1 Accuracy</strong> against <strong>flying</strong> targets.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_repurpose_engineer",
+    "name": "Repurpose",
+    "origin": {
+      "type": "Class",
+      "name": "Engineer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Engineer chooses an allied character adjacent to one of their <strong>Deployable Turrets</strong>; that character either gains {3/4/5} <strong>Overshield</strong> or gains <strong>+1 Accuracy</strong> on all attacks, checks and saves until the end of their next turn. The turret is then destroyed.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_drum_shotgun_goliath",
+    "name": "Drum Shotgun",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "This weapon ignores ranged penalties from <strong>Engaged</strong>.",
+    "tags": [],
+    "weapon_type": "Heavy CQB",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "Burn",
-                "damage": [
-                    2,
-                    3,
-                    4
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 10
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_razor_swarm_hive",
-        "name": "Razor Swarm",
-        "origin": {
-            "type": "Class",
-            "name": "Hive [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Hive deploys a <strong>Blast 1</strong> razor swarm in a free area within <strong>Sensors</strong>. Allied characters gain <strong>soft cover</strong> as long as they are at least partially within the affected area. Hostile characters start their turn at least partially within the area or move into it for the first time in a round take <strong>{2/3/4} Burn</strong>. At the start of the Hive's turn, they may move the <strong>Razor Swarm</strong> up to <strong>2 spaces</strong> in any direction, including into spaces occupied by other characters. Only a single <strong>Razor Swarm</strong> may be deployed at a time, and if a new one is deployed (or the Hive is destroyed) the old one is destroyed.",
-        "tags": [
-            {
-                "id": "tg_drone"
-            },
-            {
-                "id": "tg_quick_action"
-            }
+          5,
+          6,
+          7
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      },
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_crush_targeting_goliath",
+    "name": "Crush Targeting",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_drone_barrage_hive",
-        "name": "Drone Barrage",
-        "origin": {
-            "type": "Class",
-            "name": "Hive [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Hive makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target chooses one: they become <strong>Immobilized</strong> and <strong>Impaired</strong> until the end of their next turn, or they immediately move up to <strong>4 spaces</strong> in a direction chosen by the Hive. This movement ignores engagement and does not provoke <strong>reactions</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ]
+    "locked": false,
+    "type": "Tech",
+    "effect": "A hostile character within Sensors and line of sight gains <strong>+3 Difficulty</strong> to attack against any character other than the Goliath until the start of the Goliath’s next turn. This effect does not stack, and the effect ends immediately if the Goliath becomes <strong>Jammed</strong> or <strong>Stunned</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      }
+    ],
+    "tech_type": "Quick"
+  },
+  {
+    "id": "npc-rebake_npcf_towering_stride_goliath",
+    "name": "Towering Stride",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_driving_swarm_hive",
-        "name": "Driving Swarm",
-        "origin": {
-            "type": "Class",
-            "name": "Hive [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Whenever characters take <strong>Burn</strong> from a <strong>Razor Swarm</strong>, they must pass a <strong>Systems</strong> save or immediately move <strong>4 spaces</strong> in a direction chosen by the Hive after taking damage. This movement ignores engagement and does not provoke <strong>reactions</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Goliath can end its turn overlapping obstructions, cover, and terrain smaller than <strong>Size 3</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_heavy_frame_goliath",
+    "name": "Heavy Frame",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_harrier_maniple_hive",
-        "name": "Harrier Maniple",
-        "origin": {
-            "type": "Class",
-            "name": "Hive [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Hive releases a swarm of tiny drones and makes a tech attack against a hostile character within <strong>Sensors</strong>. On a success, the Hive pushes the target up to <strong>2 spaces</strong> in a direction of their choice and the drones create a swarming <strong>Burst 2</strong> area centered around them that lasts until the end of their next turn. All other hostile characters that start their turn at least partially within the area or move into it for the first time in a round take <strong>{2/3/4} Burn</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Goliath can’t be pushed, pulled, knocked <strong>Prone</strong>, or knocked back by smaller characters.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_guardian_goliath",
+    "name": "Guardian",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_solipsis_swarm_hive",
-        "name": "Solipsis Swarm",
-        "origin": {
-            "type": "Class",
-            "name": "Hive [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "At the start of their turn, characters within <strong>Range 3</strong> of the Hive take <strong>{2/3/4} Burn</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "Adjacent allied characters can use the Goliath for <strong>hard cover</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_power_knuckle_goliath",
+    "name": "Power Knuckle",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_electro_nanite_payloads_hive",
-        "name": "Electro-Nanite Payloads",
-        "origin": {
-            "type": "Class",
-            "name": "Hive [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Until the end of their next turn, any character that takes <strong>Burn</strong> from the Hive or a <strong>Razor Swarm</strong> makes all checks and saves at <strong>+1 Difficulty</strong>, and all Tech Attacks are made against them with <strong>+1 Accuracy</strong>. This effect of this trait does not stack.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "A character within <strong>Range 2</strong> must pass a <strong>Hull</strong> save or take <strong>{4/5/6} Kinetic damage</strong>, be pushed <strong>5 spaces</strong> directly away from the Goliath, and knocked <strong>Prone</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_pin_goliath",
+    "name": "Pin",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_command_override_hive",
-        "name": "Command Override",
-        "origin": {
-            "type": "Class",
-            "name": "Hive [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Hive chooses up to three <strong>Drones</strong> within <strong>Sensors</strong> (including those belonging to other characters) and moves them <strong>3 spaces</strong> in any direction. Then all characters adjacent to any of those <strong>Drones</strong> must pass a <strong>Systems</strong> save or take <strong>{2/3/4} Burn</strong> and gain <strong>Lock On</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            },
-            {
-                "id": "tg_heat_self",
-                "val": 4
-            },
-            {
-                "id": "tg_recharge",
-                "val": 5
-            }
-        ],
-        "tech_type": "Quick"
+    "locked": false,
+    "type": "Trait",
+    "effect": "A character within <strong>Range 2</strong> becomes <strong>Immobilized</strong> and <strong>Impaired</strong> until they either damage the Goliath, the Goliath is <strong>Stunned</strong> or destroyed, or the Goliath targets another character with this effect. The Goliath is <strong>Immobilized</strong> for the duration of this effect.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_mag_gauntlet_goliath",
+    "name": "Mag Gauntlet",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_stinger_pistol_hornet",
-        "name": "Stinger Pistol",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [],
-        "weapon_type": "Auxiliary CQB",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ],
+    "locked": false,
+    "type": "Tech",
+    "effect": "A character within <strong>Sensors</strong> and line of sight must pass a <strong>Hull</strong> save or be pulled <strong>3 spaces</strong> towards the Goliath. If they are pulled adjacent to the Goliath, they automatically become grappled. The Goliath can only grapple one character this way at a time, and can't use this system while grappling someone this way.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_coercive_force_goliath",
+    "name": "Coercive Force",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "All characters of the Goliath's choice within <strong>Sensors</strong> are pulled <strong>2 spaces</strong> towards the Goliath.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_tech"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_attractor_field_goliath",
+    "name": "Attractor Field",
+    "origin": {
+      "type": "Class",
+      "name": "Goliath [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Goliath becomes the target of the attack instead. If the attack was an area of effect, such as a <strong>Line</strong>, <strong>Cone</strong>, <strong>Blast</strong>, etc, the attacker must now position it so it targets the Goliath, or as close as possible, which could change its targets. This transfer takes place even if the attack could not have hit the Goliath (i.e. it was a melee attack).",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "An allied character within <strong>Range 2</strong> and line of sight is targeted by an attack dealing <strong>kinetic</strong> or <strong>explosive</strong> damage."
+  },
+  {
+    "id": "npc-rebake_npcf_hunter_killer_nexus_hive",
+    "name": "Hunter-Killer Nexus",
+    "origin": {
+      "type": "Class",
+      "name": "Hive [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_smart"
+      },
+      {
+        "id": "tg_seeking"
+      }
+    ],
+    "weapon_type": "Main Nexus",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "Burn",
         "damage": [
-            {
-                "type": "Energy",
-                "damage": [
-                    1,
-                    2,
-                    3
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 5
-            },
-            {
-                "type": "Threat",
-                "val": 3
-            }
-        ],
-        "on_hit": "Targets become <strong>Impaired</strong> until the end of their next turn."
-    },
-    {
-        "id": "npc-rebake_npcf_ssc_total_suite_hornet",
-        "name": "SSC Total Suite",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Hornet can <strong>hover</strong> whenever they move.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_weave_hornet",
-        "name": "Weave",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Each round, the first attack made against the Hornet as a <strong>reaction</strong> automatically fails.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_impale_systems_hornet",
-        "name": "Impale Systems",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Hornet makes a tech attack against a character within <strong>Sensors</strong>. On a hit, they take <strong>{3/4/5} Heat</strong> and become <strong>Jammed</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_tech"
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            2,
-            4,
-            6
+          2,
+          3,
+          4
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_razor_swarm_hive",
+    "name": "Razor Swarm",
+    "origin": {
+      "type": "Class",
+      "name": "Hive [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_supersonic_hornet",
-        "name": "Supersonic",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Hornet flies to a space in line of sight and <strong>Range 50</strong> so impossibly fast that it counts as <strong>teleportation</strong>. If they end this movement within <strong>Range 5</strong> of another character, that character becomes <strong>Impaired</strong> until the end of their next turn and this ability automatically recharges; If multiple characters are within <strong>Range 5</strong>, the Hornet chooses one of them.",
-        "tags": [
-            {
-                "id": "tg_full_action"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 6
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Hive deploys a <strong>Blast 1</strong> razor swarm in a free area within <strong>Sensors</strong>. Allied characters gain <strong>soft cover</strong> as long as they are at least partially within the affected area. Hostile characters start their turn at least partially within the area or move into it for the first time in a round take <strong>{2/3/4} Burn</strong>. At the start of the Hive's turn, they may move the <strong>Razor Swarm</strong> up to <strong>2 spaces</strong> in any direction, including into spaces occupied by other characters. Only a single <strong>Razor Swarm</strong> may be deployed at a time, and if a new one is deployed (or the Hive is destroyed) the old one is destroyed.",
+    "tags": [
+      {
+        "id": "tg_drone"
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_drone_barrage_hive",
+    "name": "Drone Barrage",
+    "origin": {
+      "type": "Class",
+      "name": "Hive [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_umbral_interdiction_hornet",
-        "name": "Umbral Interdiction",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "If the target is not <strong>Impaired</strong>, they immediately become <strong>Impaired</strong> until the end of their next turn. If the target is <strong>Impaired</strong>, they must pass a <strong>Systems</strong> check or their attack automatically misses.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "A character within <strong>Sensors</strong> and line of sight attempts an attack."
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Hive makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target chooses one: they become <strong>Immobilized</strong> and <strong>Impaired</strong> until the end of their next turn, or they immediately move up to <strong>4 spaces</strong> in a direction chosen by the Hive. This movement ignores engagement and does not provoke <strong>reactions</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_driving_swarm_hive",
+    "name": "Driving Swarm",
+    "origin": {
+      "type": "Class",
+      "name": "Hive [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_system_spike_hornet",
-        "name": "System Spike",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Hostile <strong>Impaired</strong> characters within the Hornet's <strong>Sensors</strong> recieve <strong>+2 Difficulty</strong> on all attacks, checks, and saves instead of <strong>+1 Difficulty</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "Whenever characters take <strong>Burn</strong> from a <strong>Razor Swarm</strong>, they must pass a <strong>Systems</strong> save or immediately move <strong>4 spaces</strong> in a direction chosen by the Hive after taking damage. This movement ignores engagement and does not provoke <strong>reactions</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_harrier_maniple_hive",
+    "name": "Harrier Maniple",
+    "origin": {
+      "type": "Class",
+      "name": "Hive [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_slingshot_hornet",
-        "name": "Slingshot",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Hornet makes a Tech Attack against a target in <strong>Sensors</strong>. On a success, they take <strong>{3/4/5} Heat</strong> and are pushed <strong>3 spaces</strong> in a direction of the Hornet's choice, then the Hornet moves to a free space within <strong>Range 5</strong> of the target as directly as possible.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 5
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ]
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Hive releases a swarm of tiny drones and makes a tech attack against a hostile character within <strong>Sensors</strong>. On a success, the Hive pushes the target up to <strong>2 spaces</strong> in a direction of their choice and the drones create a swarming <strong>Burst 2</strong> area centered around them that lasts until the end of their next turn. All other hostile characters that start their turn at least partially within the area or move into it for the first time in a round take <strong>{2/3/4} Burn</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_solipsis_swarm_hive",
+    "name": "Solipsis Swarm",
+    "origin": {
+      "type": "Class",
+      "name": "Hive [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_lock_hold_javelins_hornet",
-        "name": "Lock/Hold Javelins",
-        "origin": {
-            "type": "Class",
-            "name": "Hornet [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Hornet fires a javelin at a character within <strong>Range 5</strong> and line of sight. The target must succeed on a <strong>Hull</strong> save or be impaled, at which point the javelin tethers itself and its victim to the ground (or another surface), rendering them <strong>Immobilized</strong> and <strong>Shredded</strong>. They, or any adjacent character, can attempt to remove the javelin with a successful <strong>Hull</strong> save as a <strong>full action</strong>; otherwise, this effect lasts for the rest of the scene or until the Hornet takes this action again.",
-        "tags": [
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "At the start of their turn, characters within <strong>Range 3</strong> of the Hive take <strong>{2/3/4} Burn</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_electro_nanite_payloads_hive",
+    "name": "Electro-Nanite Payloads",
+    "origin": {
+      "type": "Class",
+      "name": "Hive [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_raptor_plasma_rifle_operator",
-        "name": "Raptor Plasma Rifle",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_reliable",
-                "val": "{2/3/4}"
-            }
-        ],
-        "weapon_type": "Heavy Rifle",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Trait",
+    "effect": "Until the end of their next turn, any character that takes <strong>Burn</strong> from the Hive or a <strong>Razor Swarm</strong> makes all checks and saves at <strong>+1 Difficulty</strong>, and all Tech Attacks are made against them with <strong>+1 Accuracy</strong>. This effect of this trait does not stack.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_command_override_hive",
+    "name": "Command Override",
+    "origin": {
+      "type": "Class",
+      "name": "Hive [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Hive chooses up to three <strong>Drones</strong> within <strong>Sensors</strong> (including those belonging to other characters) and moves them <strong>3 spaces</strong> in any direction. Then all characters adjacent to any of those <strong>Drones</strong> must pass a <strong>Systems</strong> save or take <strong>{2/3/4} Burn</strong> and gain <strong>Lock On</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      },
+      {
+        "id": "tg_heat_self",
+        "val": 4
+      },
+      {
+        "id": "tg_recharge",
+        "val": 5
+      }
+    ],
+    "tech_type": "Quick"
+  },
+  {
+    "id": "npc-rebake_npcf_stinger_pistol_hornet",
+    "name": "Stinger Pistol",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [],
+    "weapon_type": "Auxiliary CQB",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ],
+    "damage": [
+      {
+        "type": "Energy",
         "damage": [
-            {
-                "type": "Energy",
-                "damage": [
-                    6,
-                    8,
-                    10
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 10
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_trace_drive_operator",
-        "name": "Trace Drive",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Operator <strong>teleports</strong> when they make their standard move. Whenever the Operator exceeds their <strong>Heat Cap</strong>, this system is disabled until the end of their next turn.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_strike_and_fade_operator",
-        "name": "Strike and Fade",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Whenever the Operator <strong>teleports</strong> during their turn before making any attacks, they gain <strong>+1 Accuracy</strong> on all attacks with the <strong>Raptor Plasma Rifle</strong> until the end of their turn. Whenever the Operator <strong>teleports</strong> during their turn after making any attacks, all attacks against them recieve <strong>+1 Difficulty</strong> until the end of their next turn.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_self_erasure_operator",
-        "name": "Self-Erasure",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When the Operator is destroyed, it immediately self-immolates in a wave of superheated plasma. All characters adjacent to the Operator when this takes place must succeed on an <strong>Agility</strong> save or take <strong>{4/6/8} Energy damage</strong> and rendered only able to draw line of sight to adjacent spaces until the end of their next. On a success, they take half damage only. This mech is then removed from the battlefield – it is utterly annihilated.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_telefrag_operator",
-        "name": "Telefrag",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Operator <strong>teleports</strong> into a space occupied by another character within line of sight and <strong>range 15</strong>. The target must succeed on an <strong>Agility</strong> save or take <strong>{4/5/6} AP Energy damage</strong> and become <strong>Jammed</strong> and <strong>Shredded</strong> until the end of their next turn. On a successful save, they take half damage only. Succeed or fail, the Operator takes <strong>1d6 AP Energy damage</strong> and then <strong>teleports</strong> to a new space within <strong>Range 5</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 6
-            }
+          1,
+          2,
+          3
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      },
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "on_hit": "Targets become <strong>Impaired</strong> until the end of their next turn."
+  },
+  {
+    "id": "npc-rebake_npcf_ssc_total_suite_hornet",
+    "name": "SSC Total Suite",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_overload_shot_operator",
-        "name": "Overload Shot",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Operator makes an attack with the <strong>Raptor Plasma Rifle</strong>, treating its <strong>Range</strong> as <strong>Line 10</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Hornet can <strong>hover</strong> whenever they move.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_weave_hornet",
+    "name": "Weave",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_fade_generator_operator",
-        "name": "Fade Generator",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Operator teleports to a space within <strong>Range 2</strong>. They may choose to teleport further taking <strong>1d6 Heat</strong> and adding that many additonal spaces to the movement.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "The Operator takes damage from a ranged or melee attack."
+    "locked": false,
+    "type": "Trait",
+    "effect": "Each round, the first attack made against the Hornet as a <strong>reaction</strong> automatically fails.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_impale_systems_hornet",
+    "name": "Impale Systems",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_singularity_grenade_operator",
-        "name": "Singularity Grenade",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Operator may expend a charge to throw a grenade to a space within <strong>Range 5</strong>. Characters in the <strong>Blast 2</strong> energy pulse (excluding the Operator) must pass a <strong>Systems</strong> save or be <strong>teleported 2 spaces</strong> in a direction of the Operator's choice and treat the Operator as <strong>Invisible</strong> until the end of their next turn.<Br>The Operator then <strong>teleports</strong> their <strong>Speed</strong>.",
-        "tags": [
-            {
-                "id": "tg_grenade"
-            },
-            {
-                "id": "tg_limited",
-                "val": 1
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Hornet makes a tech attack against a character within <strong>Sensors</strong>. On a hit, they take <strong>{3/4/5} Heat</strong> and become <strong>Jammed</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_tech"
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_supersonic_hornet",
+    "name": "Supersonic",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_deniable_asset_operator",
-        "name": "Deniable Asset",
-        "origin": {
-            "type": "Class",
-            "name": "Operator [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Self Erasure now deals <strong>{6/8/10} damage</strong> (half on a successful save), and when the Operator is destroyed they may immediately <strong>teleport</strong> their <strong>Speed</strong> as a <strong>Reaction</strong> before self-immolating.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Hornet flies to a space in line of sight and <strong>Range 50</strong> so impossibly fast that it counts as <strong>teleportation</strong>. If they end this movement within <strong>Range 5</strong> of another character, that character becomes <strong>Impaired</strong> until the end of their next turn and this ability automatically recharges; If multiple characters are within <strong>Range 5</strong>, the Hornet chooses one of them.",
+    "tags": [
+      {
+        "id": "tg_full_action"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 6
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_umbral_interdiction_hornet",
+    "name": "Umbral Interdiction",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_flamethrower_pyro",
-        "name": "Flamethrower",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "This weapon deals <strong>double Burn</strong> to characters that already have any <strong>Burn</strong>.",
-        "tags": [
-            {
-                "id": "tg_heat_self",
-                "val": 4
-            }
-        ],
-        "weapon_type": "Heavy CQB",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "Reaction",
+    "effect": "If the target is not <strong>Impaired</strong>, they immediately become <strong>Impaired</strong> until the end of their next turn. If the target is <strong>Impaired</strong>, they must pass a <strong>Systems</strong> check or their attack automatically misses.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "A character within <strong>Sensors</strong> and line of sight attempts an attack."
+  },
+  {
+    "id": "npc-rebake_npcf_system_spike_hornet",
+    "name": "System Spike",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "Hostile <strong>Impaired</strong> characters within the Hornet's <strong>Sensors</strong> recieve <strong>+2 Difficulty</strong> on all attacks, checks, and saves instead of <strong>+1 Difficulty</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_slingshot_hornet",
+    "name": "Slingshot",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Hornet makes a Tech Attack against a target in <strong>Sensors</strong>. On a success, they take <strong>{3/4/5} Heat</strong> and are pushed <strong>3 spaces</strong> in a direction of the Hornet's choice, then the Hornet moves to a free space within <strong>Range 5</strong> of the target as directly as possible.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 5
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_lock_hold_javelins_hornet",
+    "name": "Lock/Hold Javelins",
+    "origin": {
+      "type": "Class",
+      "name": "Hornet [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Hornet fires a javelin at a character within <strong>Range 5</strong> and line of sight. The target must succeed on a <strong>Hull</strong> save or be impaled, at which point the javelin tethers itself and its victim to the ground (or another surface), rendering them <strong>Immobilized</strong> and <strong>Shredded</strong>. They, or any adjacent character, can attempt to remove the javelin with a successful <strong>Hull</strong> save as a <strong>full action</strong>; otherwise, this effect lasts for the rest of the scene or until the Hornet takes this action again.",
+    "tags": [
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_raptor_plasma_rifle_operator",
+    "name": "Raptor Plasma Rifle",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_reliable",
+        "val": "{2/3/4}"
+      }
+    ],
+    "weapon_type": "Heavy Rifle",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Energy",
         "damage": [
-            {
-                "type": "Burn",
-                "damage": [
-                    3,
-                    4,
-                    5
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Cone",
-                "val": 5
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_firebreak_shield_pyro",
-        "name": "Firebreak Shield",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "At the end of the Pyro's turn, they create a <strong>Line 5</strong> wall of flame, <strong>4 spaces high</strong>, in free spaces within <strong>Range 3</strong> and line of sight. This wall doesn't block line of sight, but provides <strong>soft cover</strong>; when an attack is made against a character benefiting from this cover, roll <strong>1d6</strong>. On a <strong>4+</strong>, that attack misses. Characters can pass through this wall, but when crossing the wall for the first time in a round or starting their turn overlapping its spaces, they take <strong>{2/3/4} Burn</strong>. This wall lasts until the start of the Pyro's next turn, or until the Pyro moves or is <strong>Stunned</strong>, and its effect doesn't stack with <strong>Invisible</strong>.",
-        "tags": [
-            {
-                "id": "tg_shield"
-            }
+          6,
+          8,
+          10
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_trace_drive_operator",
+    "name": "Trace Drive",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_explosive_vent_pyro",
-        "name": "Explosive Vent",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Pyro clears all <strong>Heat</strong>. All characters within <strong>Burst 2</strong> must pass an <strong>Agility</strong> save or take <strong>Heat</strong> equal to <strong>half the amount the Pyro cleared</strong> and be knocked <strong>Prone</strong>.",
-        "tags": [
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Operator <strong>teleports</strong> when they make their standard move. Whenever the Operator exceeds their <strong>Heat Cap</strong>, this system is disabled until the end of their next turn.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_strike_and_fade_operator",
+    "name": "Strike and Fade",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_insulated_pyro",
-        "name": "Insulated",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Pyro has <strong>Immunity</strong> to <strong>Burn</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "Whenever the Operator <strong>teleports</strong> during their turn before making any attacks, they gain <strong>+1 Accuracy</strong> on all attacks with the <strong>Raptor Plasma Rifle</strong> until the end of their turn. Whenever the Operator <strong>teleports</strong> during their turn after making any attacks, all attacks against them recieve <strong>+1 Difficulty</strong> until the end of their next turn.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_self_erasure_operator",
+    "name": "Self-Erasure",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_napalm_bomb_pyro",
-        "name": "Napalm Bomb",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Pyro launches a napalm canister that erupts in a <strong>Blast 1</strong> curtain of flame within Range 5. All characters within this area must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and <strong>{2/3/4} Heat</strong>. The Pyro may instead target a free area with this <strong>Blast</strong>; if they do, it creates a burning patch on the ground that lasts until this system is used again. Characters that start their turn at least partially within the area or move into it for the first time in a round must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and <strong>{2/3/4 Heat}</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": "5"
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "When the Operator is destroyed, it immediately self-immolates in a wave of superheated plasma. All characters adjacent to the Operator when this takes place must succeed on an <strong>Agility</strong> save or take <strong>{4/6/8} Energy damage</strong> and rendered only able to draw line of sight to adjacent spaces until the end of their next. On a success, they take half damage only. This mech is then removed from the battlefield – it is utterly annihilated.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_telefrag_operator",
+    "name": "Telefrag",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_unshielded_reactor_pyro",
-        "name": "Unshielded Reactor",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Characters that start their turn within <strong>Range 3</strong> of the Pyro or who move into <strong>Range 3</strong> of them for the first time in a round take <strong>2/3/4 Heat</strong>, and they make all checks to clear <strong>Burn</strong> with <strong>+1 Difficulty</strong> as long as they remain within <strong>3 spaces</strong> of the Pyro.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Operator <strong>teleports</strong> into a space occupied by another character within line of sight and <strong>range 15</strong>. The target must succeed on an <strong>Agility</strong> save or take <strong>{4/5/6} AP Energy damage</strong> and become <strong>Jammed</strong> and <strong>Shredded</strong> until the end of their next turn. On a successful save, they take half damage only. Succeed or fail, the Operator takes <strong>1d6 AP Energy damage</strong> and then <strong>teleports</strong> to a new space within <strong>Range 5</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 6
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_overload_shot_operator",
+    "name": "Overload Shot",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_superhot_pyro",
-        "name": "Superhot",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Pyro gains <strong>Resistance</strong> to all damage from the attack. The attacker must pass an <strong>Engineering</strong> save or take {3/4/5} <strong>Burn</strong>.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            },
-            {
-                "id": "tg_heat_self",
-                "val": "4"
-            }
-        ],
-        "trigger": "The Pyro takes damage from a melee attack."
+    "locked": false,
+    "type": "System",
+    "effect": "The Operator makes an attack with the <strong>Raptor Plasma Rifle</strong>, treating its <strong>Range</strong> as <strong>Line 10</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_fade_generator_operator",
+    "name": "Fade Generator",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_explosive_jet_pyro",
-        "name": "Explosive Jet",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "Hostile characters within <strong>Burst 2</strong> must pass a <strong>Hull</strong> save or be knocked back outside of the area and knocked <strong>Prone</strong>. The Pyro then flies <strong>5 spaces</strong> in any direction, but must land after completing that move. If the Pyro is in the <strong>Danger Zone</strong>, the <strong>Hull</strong> save is made with <strong>+1 Difficulty</strong> and this system's <strong>Recharge</strong> rolls automatically succeed.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Operator teleports to a space within <strong>Range 2</strong>. They may choose to teleport further taking <strong>1d6 Heat</strong> and adding that many additonal spaces to the movement.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "The Operator takes damage from a ranged or melee attack."
+  },
+  {
+    "id": "npc-rebake_npcf_singularity_grenade_operator",
+    "name": "Singularity Grenade",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_lingering_flames_pyro",
-        "name": "Lingering Flames",
-        "origin": {
-            "type": "Class",
-            "name": "Pyro [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When the Pyro attacks with the <strong>Flamethrower</strong>, flames continue to Burn in <strong>3 free spaces</strong> of their choice within the affected area. When characters start their turn in one of these spaces or enter one for the first time in a round, they take <strong>{2/3/4} Burn</strong>. These spaces last until the end of the scene, or until the Pyro attacks with the <strong>Flamethrower</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "The Operator may expend a charge to throw a grenade to a space within <strong>Range 5</strong>. Characters in the <strong>Blast 2</strong> energy pulse (excluding the Operator) must pass a <strong>Systems</strong> save or be <strong>teleported 2 spaces</strong> in a direction of the Operator's choice and treat the Operator as <strong>Invisible</strong> until the end of their next turn.<Br>The Operator then <strong>teleports</strong> their <strong>Speed</strong>.",
+    "tags": [
+      {
+        "id": "tg_grenade"
+      },
+      {
+        "id": "tg_limited",
+        "val": 1
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_deniable_asset_operator",
+    "name": "Deniable Asset",
+    "origin": {
+      "type": "Class",
+      "name": "Operator [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_carbon_fiber_sword_ronin",
-        "name": "Carbon Fiber Sword",
-        "origin": {
-            "type": "Class",
-            "name": "Ronin [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "tags": [],
-        "weapon_type": "Main Melee",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ],
+    "locked": false,
+    "type": "Trait",
+    "effect": "Self Erasure now deals <strong>{6/8/10} damage</strong> (half on a successful save), and when the Operator is destroyed they may immediately <strong>teleport</strong> their <strong>Speed</strong> as a <strong>Reaction</strong> before self-immolating.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_flamethrower_pyro",
+    "name": "Flamethrower",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "This weapon deals <strong>double Burn</strong> to characters that already have any <strong>Burn</strong>.",
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 4
+      }
+    ],
+    "weapon_type": "Heavy CQB",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "Burn",
         "damage": [
-            {
-                "type": "Kinetic",
-                "damage": [
-                    6,
-                    8,
-                    10
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 2
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_rebound_ronin",
-        "name": "Rebound",
-        "origin": {
-            "type": "Class",
-            "name": "Ronin [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "They roll <strong>1d6</strong>: on <strong>4+</strong>, they gain <strong>Resistance</strong> to damage from that attack, and the attacker must repeat the attack against themselves. On <strong>3 or less</strong>, the Ronin may <strong>Boost</strong> towards the triggering attacker.",
-        "tags": [
-            {
-                "id": "tg_shield"
-            },
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "The Ronin takes damage from a ranged attack."
-    },
-    {
-        "id": "npc-rebake_npcf_counter-ballistic_suite_ronin",
-        "name": "Counter-Ballistic Suite",
-        "origin": {
-            "type": "Class",
-            "name": "Ronin [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Whenever a character makes a ranged attack against the Ronin, that character gains a <strong>Ronin's Mark</strong>. Only one character at a time can have a <strong>Ronin's Mark</strong>; if a new mark is applied, any others are removed. When the Ronin makes a successful attack against a character using the <strong>Carbon Fiber Sword</strong>, it can consume the <strong>Ronin's Mark</strong> to deal <strong>+1d6 bonus damage</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_chaff_launchers_ronin",
-        "name": "Chaff Launchers",
-        "origin": {
-            "type": "Class",
-            "name": "Ronin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Ranged attacks against the Ronin while <strong>Engaged</strong> receive <strong>+2 Difficulty</strong> instead of <strong>+1 Difficulty</strong>, and the Ronin gains <strong>soft cover</strong> until the start of their next turn whenever they <strong>Boost</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_instinct_mode_ronin",
-        "name": "Instinct Mode",
-        "origin": {
-            "type": "Class",
-            "name": "Ronin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Ronin enters a prepared stance, visible to everyone. Until the end of the Ronin’s next turn, the first time each turn that a hostile character in line of sight makes a ranged attack, as a <strong>reaction</strong> the Ronin may first <strong>Boost</strong> towards the triggering attacker and then make an attack against them with the <strong>Carbon Fiber Sword</strong> if they are within <strong>Range</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_action"
-            }
+          3,
+          4,
+          5
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Cone",
+        "val": 5
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_firebreak_shield_pyro",
+    "name": "Firebreak Shield",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_mag_field_ronin",
-        "name": "Mag Field",
-        "origin": {
-            "type": "Class",
-            "name": "Ronin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Whenever the Ronin takes damage or effects from missed attacks (e.g. <strong>Reliable</strong>), they may choose a different character within <strong>Range 5</strong> to also take the damage or effects.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "At the end of the Pyro's turn, they create a <strong>Line 5</strong> wall of flame, <strong>4 spaces high</strong>, in free spaces within <strong>Range 3</strong> and line of sight. This wall doesn't block line of sight, but provides <strong>soft cover</strong>; when an attack is made against a character benefiting from this cover, roll <strong>1d6</strong>. On a <strong>4+</strong>, that attack misses. Characters can pass through this wall, but when crossing the wall for the first time in a round or starting their turn overlapping its spaces, they take <strong>{2/3/4} Burn</strong>. This wall lasts until the start of the Pyro's next turn, or until the Pyro moves or is <strong>Stunned</strong>, and its effect doesn't stack with <strong>Invisible</strong>.",
+    "tags": [
+      {
+        "id": "tg_shield"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_explosive_vent_pyro",
+    "name": "Explosive Vent",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_charged_slash_ronin",
-        "name": "Charged Slash",
-        "origin": {
-            "type": "Class",
-            "name": "Ronin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "An adjacent character must pass an <strong>Agility</strong> save or choose: become <strong>Jammed</strong> until the end of their next turn, or the Ronin chooses one of their equipped weapons and they take half that weapon's damage from a ruptured magazine or power cell, then they become <strong>Impaired</strong> until the end of their next turn. On a success, they become <strong>Impaired</strong> until the end of their next turn only.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Pyro clears all <strong>Heat</strong>. All characters within <strong>Burst 2</strong> must pass an <strong>Agility</strong> save or take <strong>Heat</strong> equal to <strong>half the amount the Pyro cleared</strong> and be knocked <strong>Prone</strong>.",
+    "tags": [
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_insulated_pyro",
+    "name": "Insulated",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_extended_blade_ronin",
-        "name": "Extended Blade",
-        "origin": {
-            "type": "Class",
-            "name": "Ronin [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Ronin’s <strong>Carbon Fiber Sword</strong> becomes <strong>Threat 3</strong>. The first time each turn that the Ronin performs a critical hit with it, all characters of their choice within <strong>Threat</strong> take <strong>{2/3/4} Kinetic damage</strong>, excluding the target just attacked.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Pyro has <strong>Immunity</strong> to <strong>Burn</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_napalm_bomb_pyro",
+    "name": "Napalm Bomb",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_thermal_lance_scourer",
-        "name": "Thermal Lance",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_heat_self",
-                "val": 4
-            }
-        ],
-        "weapon_type": "Heavy Cannon",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ],
+    "locked": false,
+    "type": "System",
+    "effect": "The Pyro launches a napalm canister that erupts in a <strong>Blast 1</strong> curtain of flame within Range 5. All characters within this area must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and <strong>{2/3/4} Heat</strong>. The Pyro may instead target a free area with this <strong>Blast</strong>; if they do, it creates a burning patch on the ground that lasts until this system is used again. Characters that start their turn at least partially within the area or move into it for the first time in a round must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and <strong>{2/3/4 Heat}</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": "5"
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_unshielded_reactor_pyro",
+    "name": "Unshielded Reactor",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "Characters that start their turn within <strong>Range 3</strong> of the Pyro or who move into <strong>Range 3</strong> of them for the first time in a round take <strong>2/3/4 Heat</strong>, and they make all checks to clear <strong>Burn</strong> with <strong>+1 Difficulty</strong> as long as they remain within <strong>3 spaces</strong> of the Pyro.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_superhot_pyro",
+    "name": "Superhot",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Pyro gains <strong>Resistance</strong> to all damage from the attack. The attacker must pass an <strong>Engineering</strong> save or take {3/4/5} <strong>Burn</strong>.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      },
+      {
+        "id": "tg_heat_self",
+        "val": "4"
+      }
+    ],
+    "trigger": "The Pyro takes damage from a melee attack."
+  },
+  {
+    "id": "npc-rebake_npcf_explosive_jet_pyro",
+    "name": "Explosive Jet",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "Hostile characters within <strong>Burst 2</strong> must pass a <strong>Hull</strong> save or be knocked back outside of the area and knocked <strong>Prone</strong>. The Pyro then flies <strong>5 spaces</strong> in any direction, but must land after completing that move. If the Pyro is in the <strong>Danger Zone</strong>, the <strong>Hull</strong> save is made with <strong>+1 Difficulty</strong> and this system's <strong>Recharge</strong> rolls automatically succeed.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_lingering_flames_pyro",
+    "name": "Lingering Flames",
+    "origin": {
+      "type": "Class",
+      "name": "Pyro [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "When the Pyro attacks with the <strong>Flamethrower</strong>, flames continue to Burn in <strong>3 free spaces</strong> of their choice within the affected area. When characters start their turn in one of these spaces or enter one for the first time in a round, they take <strong>{2/3/4} Burn</strong>. These spaces last until the end of the scene, or until the Pyro attacks with the <strong>Flamethrower</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_carbon_fiber_sword_ronin",
+    "name": "Carbon Fiber Sword",
+    "origin": {
+      "type": "Class",
+      "name": "Ronin [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "tags": [],
+    "weapon_type": "Main Melee",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ],
+    "damage": [
+      {
+        "type": "Kinetic",
         "damage": [
-            {
-                "type": "Energy",
-                "damage": [
-                    6,
-                    8,
-                    10
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 8
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_focus_down_scourer",
-        "name": "Focus Down",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When the Scourer hits with the <strong>Thermal Lance</strong>, targets take <strong>{5/6/7} Burn</strong> if they were also successfully hit with the <strong>Thermal Lance</strong> in the previous round.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_cooling_module_scourer",
-        "name": "Cooling Module",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "At the start of their turn, the Scourer <strong>clears all Heat</strong> if they haven’t moved – including involuntary movement – since the end of their previous turn.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_ablative_shielding_scourer",
-        "name": "Ablative Shielding",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Scourer has <strong>Resistance</strong> to <strong>Energy damage</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_supercharged_scourer",
-        "name": "Supercharged",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Characters affected by <strong>Focus Down</strong> are also <strong>Shredded</strong> and <strong>Slowed</strong> until the end of their next turn.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_emergency_vent_scourer",
-        "name": "Emergency Vent",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "When the Scourer exceeds their <strong>Heat Cap</strong>, becomes <strong>Jammed</strong>, or becomes <strong>Stunned</strong>, they become <strong>Invisible</strong> until the start of their next turn.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_pulse_laser_scourer",
-        "name": "Pulse Laser",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When the Scourer makes an attack with the <strong>Thermal Lance</strong>, they can attack two targets at a time, dealing half damage on hit. This trait automatically <strong>Recharges</strong> whenever <strong>Cooling Module</strong> activates.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            }
+          6,
+          8,
+          10
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 2
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_rebound_ronin",
+    "name": "Rebound",
+    "origin": {
+      "type": "Class",
+      "name": "Ronin [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_melt_scourer",
-        "name": "Melt",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Scourer makes a ranged attack against an object, deployable or <strong>Drone</strong> within <strong>Range 10</strong>, dealing <strong>20 AP Energy damage</strong> on a success. On hit, all characters within a <strong>Burst 2</strong> radius of the target are splashed with molten slag, and count as being successfully hit with the <strong>Thermal Lance</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Reaction",
+    "effect": "They roll <strong>1d6</strong>: on <strong>4+</strong>, they gain <strong>Resistance</strong> to damage from that attack, and the attacker must repeat the attack against themselves. On <strong>3 or less</strong>, the Ronin may <strong>Boost</strong> towards the triggering attacker.",
+    "tags": [
+      {
+        "id": "tg_shield"
+      },
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "The Ronin takes damage from a ranged attack."
+  },
+  {
+    "id": "npc-rebake_npcf_counter-ballistic_suite_ronin",
+    "name": "Counter-Ballistic Suite",
+    "origin": {
+      "type": "Class",
+      "name": "Ronin [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_thermal_overload_scourer",
-        "name": "Thermal Overload",
-        "origin": {
-            "type": "Class",
-            "name": "Scourer [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "If the <strong>Cooling Module</strong> does not activate at the start of the Scourer's turn, the <strong>Thermal Lance</strong> gains <strong>+4 Range</strong>, and on hit all other characters in a <strong>Burst 1</strong> area around the target take <strong>{3/4/5} Burn</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "Whenever a character makes a ranged attack against the Ronin, that character gains a <strong>Ronin's Mark</strong>. Only one character at a time can have a <strong>Ronin's Mark</strong>; if a new mark is applied, any others are removed. When the Ronin makes a successful attack against a character using the <strong>Carbon Fiber Sword</strong>, it can consume the <strong>Ronin's Mark</strong> to deal <strong>+1d6 bonus damage</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_chaff_launchers_ronin",
+    "name": "Chaff Launchers",
+    "origin": {
+      "type": "Class",
+      "name": "Ronin [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_marker_rifle_scout",
-        "name": "Marker Rifle",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_smart"
-            }
-        ],
-        "weapon_type": "Main Rifle",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ],
-        "damage": [],
-        "range": [
-            {
-                "type": "Range",
-                "val": 15
-            }
-        ],
-        "on_hit": "Target receives <strong>Lock On</strong>, and they become <strong>Shredded</strong> until the end of their next turn."
+    "locked": false,
+    "type": "Trait",
+    "effect": "Ranged attacks against the Ronin while <strong>Engaged</strong> receive <strong>+2 Difficulty</strong> instead of <strong>+1 Difficulty</strong>, and the Ronin gains <strong>soft cover</strong> until the start of their next turn whenever they <strong>Boost</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_instinct_mode_ronin",
+    "name": "Instinct Mode",
+    "origin": {
+      "type": "Class",
+      "name": "Ronin [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_sight_scout",
-        "name": "Sight",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Scout ignores <strong>Hidden</strong> and <strong>Invisible</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "The Ronin enters a prepared stance, visible to everyone. Until the end of the Ronin’s next turn, the first time each turn that a hostile character in line of sight makes a ranged attack, as a <strong>reaction</strong> the Ronin may first <strong>Boost</strong> towards the triggering attacker and then make an attack against them with the <strong>Carbon Fiber Sword</strong> if they are within <strong>Range</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_mag_field_ronin",
+    "name": "Mag Field",
+    "origin": {
+      "type": "Class",
+      "name": "Ronin [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_rebound_scan_scout",
-        "name": "Rebound Scan",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Scout makes a tech attack against a target in Sensors. On a success, the target and all hostile characters within <strong>Range 3</strong> of the target lose <strong>Hidden</strong> and <strong>Invisible</strong> and can't regain either status or benefit from any cover until the start of the Scout's next turn.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 4
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            2,
-            3,
-            4
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "Whenever the Ronin takes damage or effects from missed attacks (e.g. <strong>Reliable</strong>), they may choose a different character within <strong>Range 5</strong> to also take the damage or effects.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_charged_slash_ronin",
+    "name": "Charged Slash",
+    "origin": {
+      "type": "Class",
+      "name": "Ronin [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_cloaking_field_scout",
-        "name": "Cloaking Field",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Scout generates a <strong>Burst 3</strong> cloaking field that lasts until the end of their next turn. The Scout and allied characters within the affected area are <strong>Invisible</strong>, but the Scout is <strong>Immobilized</strong> while it is active.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "An adjacent character must pass an <strong>Agility</strong> save or choose: become <strong>Jammed</strong> until the end of their next turn, or the Ronin chooses one of their equipped weapons and they take half that weapon's damage from a ruptured magazine or power cell, then they become <strong>Impaired</strong> until the end of their next turn. On a success, they become <strong>Impaired</strong> until the end of their next turn only.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_extended_blade_ronin",
+    "name": "Extended Blade",
+    "origin": {
+      "type": "Class",
+      "name": "Ronin [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_spotter_scout",
-        "name": "Spotter",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "While adjacent to the Scout, allied characters gain <strong>+1 Accuracy</strong> on all attack rolls.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "The Ronin’s <strong>Carbon Fiber Sword</strong> becomes <strong>Threat 3</strong>. The first time each turn that the Ronin performs a critical hit with it, all characters of their choice within <strong>Threat</strong> take <strong>{2/3/4} Kinetic damage</strong>, excluding the target just attacked.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_thermal_lance_scourer",
+    "name": "Thermal Lance",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_scout_drone_scout",
-        "name": "Scout Drone",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "<strong>Scout Drone</strong> (<strong>Size</strong> 1/2, <strong>HP</strong> {5/8/10}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags</strong>: Drone)<br>The Scout deploys the drone to a free space within <strong>Sensors</strong> The drone creates a <strong>Burst 2</strong> perimeter, within which characters cannot become <strong>Invisible</strong> or <strong>Hide</strong>, and lose those conditions if they have them. The Scout and all allied characters also gain <strong>+1 Accuracy</strong> when attacking characters within the affected area. The drone can be deployed to a new location as a protocol.",
-        "tags": [
-            {
-                "id": "tg_drone"
-            },
-            {
-                "id": "tg_limited",
-                "val": 1
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_orbital_strike_scout",
-        "name": "Orbital Strike",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Scout chooses a space on the ground, within line of sight and <strong>Range 20</strong>; all characters know that it has been chosen. The Scout calls in an orbital bombardment that hits at the end of the next round, creating a <strong>Burst 2</strong> explosion. Characters in the affected area must make <strong>Agility</strong> saves. On a fail, they take <strong>{12/16/20} Energy damage</strong> and are knocked <strong>Prone</strong>. On a pass, they take half damage and remain standing.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_full_action"
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_expose_weakness_scout",
-        "name": "Expose Weakness",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Characters that are successfully attacked with the <strong>Marker Rifle</strong> gain a <strong>Scout's Mark</strong>. Only one character can be marked this way at a time, and marking another character clears any marks from the last one. The next time an ally successfully hits a character with a <strong>Scout's Mark</strong>, they may consume the mark to choose one of the following:<ul><li>The Target takes <strong>+1d6 bonus damage</strong>.</li><li>The target is knocked <strong>Prone</strong>.</li><li>The target only has line of sight to adjacent spaces until the end of their next turn</li><ul>",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_pathfinder_scout",
-        "name": "Pathfinder",
-        "origin": {
-            "type": "Class",
-            "name": "Scout [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "<strong>1/round</strong>, whenever the Scout successfully attacks with the <strong>Marker Rifle</strong>, an allied character within <strong>Sensors</strong> and line of sight can move up to their <strong>Speed</strong> as a Reaction.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_grav_grenade_launcher_seeder",
-        "name": "Grav-Grenade Launcher",
-        "origin": {
-            "type": "Class",
-            "name": "Seeder [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_arcing"
-            }
-        ],
-        "weapon_type": "Main Launcher",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 4
+      }
+    ],
+    "weapon_type": "Heavy Cannon",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ],
+    "damage": [
+      {
+        "type": "Energy",
         "damage": [
-            {
-                "type": "Explosive",
-                "damage": [
-                    2,
-                    3,
-                    4
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 8
-            },
-            {
-                "type": "Blast",
-                "val": 1
-            }
-        ],
-        "on_hit": "Targets are pulled <strong>1 space</strong> in a direction of the Seeder's choice."
-    },
-    {
-        "id": "npc-rebake_npcf_lay_mines_seeder",
-        "name": "Lay Mines",
-        "origin": {
-            "type": "Class",
-            "name": "Seeder [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Seeder deploys one of the mines below in a free space within <strong>Range 3</strong>. Once deployed, the Seeder’s mines detonate when a hostile character moves adjacent to them, creating a <strong>Burst 1</strong> explosion that affects both allied and hostile characters.<ul><li><strong>Sealant Mine</strong>: Characters in the area must pass a <strong>Hull</strong> save or become <strong>Immobilized</strong> until the end of their next turn, then <strong>Slowed</strong> until the end of their subsequent turn.</li><li><strong>Explosive Mine</strong>: Characters in the area must pass an <strong>Agility</strong> save or take <strong>8/12/16 explosive damage</strong>. On a success, they take <strong>half damage</strong>.</li><li><strong>Shock Mine</strong>: Characters in the area must pass a <strong>Systems</strong> save or become <strong>Jammed</strong> until the end of their next turn, then <strong>Impaired</strong> until the end of their subsequent turn.</li><li><strong>Thermite Mine</strong>: Characters in the area must pass an <strong>Engineering</strong> save or take 4/5/6 Heat and have only line of sight to adjacent spaces until the end of their next turn. On a success, they take <strong>half Heat only</strong>.</li></ul><br>The Seeder may have up to <strong>three mines</strong> deployed at a time; if they deploy another mine, one of their currently deployed mines of their choice disarms and deactivates. When the Seeder is destroyed, its deployed mines remain active, but now detonate whenever any character moves adjacent to them.",
-        "tags": [
-            {
-                "id": "tg_mine"
-            },
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_turn",
-                "val": 1
-            }
+          6,
+          8,
+          10
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 8
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_focus_down_scourer",
+    "name": "Focus Down",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_safety_net_seeder",
-        "name": "Safety Net",
-        "origin": {
-            "type": "Class",
-            "name": "Seeder [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Seeder never triggers or sets off <strong>Mines</strong> or other proximity-based systems unless it chooses to do so.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "When the Scourer hits with the <strong>Thermal Lance</strong>, targets take <strong>{5/6/7} Burn</strong> if they were also successfully hit with the <strong>Thermal Lance</strong> in the previous round.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_cooling_module_scourer",
+    "name": "Cooling Module",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_grav_spike_seeder",
-        "name": "Grav Spike",
-        "origin": {
-            "type": "Class",
-            "name": "Seeder [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "A character within line of sight and <strong>Range 5</strong> must succeed on a <strong>Systems</strong> save, or a grav spike attaches itself to them. The Seeder can detonate all grav spikes as a <strong>protocol</strong>, causing targets to automatically take <strong>4/5/6 AP explosive damage</strong> and be pulled <strong>3 spaces</strong> in a direction of their choice. Characters can remove a grav spike from themselves by passing a <strong>Systems</strong> save as a <strong>quick action</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "At the start of their turn, the Scourer <strong>clears all Heat</strong> if they haven’t moved – including involuntary movement – since the end of their previous turn.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_ablative_shielding_scourer",
+    "name": "Ablative Shielding",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_FASCAM_seeder",
-        "name": "FASCAM",
-        "origin": {
-            "type": "Class",
-            "name": "Seeder [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Seeder launches a rocket which scatters a field of explosive micromines over a <strong>Blast 3</strong> area within <strong>Sensors</strong>; this area can overlap with obstructions (like cover or terrain) when deployed, but not characters. Characters who enter this area or attempt to move while within it for the first time in a round must pass a <strong>Systems</strong> save or step on a mine, taking <strong>5/6/7 explosive damage</strong>. Only one field of micromines can exist at a time, and if a new one is created, the previous one deactivates.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Scourer has <strong>Resistance</strong> to <strong>Energy damage</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_supercharged_scourer",
+    "name": "Supercharged",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_speed_deployer_seeder",
-        "name": "Speed Deployer",
-        "origin": {
-            "type": "Class",
-            "name": "Seeder [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "<strong>Lay Mines</strong> may now deploy up to <strong>three mines</strong> at a time instead of just one. If the Seeder deploys more than one mine at a time this way, this trait can't be used again until one of its mines detonates or is disarmed.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "Characters affected by <strong>Focus Down</strong> are also <strong>Shredded</strong> and <strong>Slowed</strong> until the end of their next turn.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_emergency_vent_scourer",
+    "name": "Emergency Vent",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_hopping_mines_seeder",
-        "name": "Hopping Mines",
-        "origin": {
-            "type": "Class",
-            "name": "Seeder [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Mines deployed with <strong>Lay Mines</strong> also activate when hostile characters fly or move over or adjacent to them, up to <strong>10 spaces</strong> high. The mines jump up to <strong>10 spaces</strong>, detonating and affecting all characters within their area.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "When the Scourer exceeds their <strong>Heat Cap</strong>, becomes <strong>Jammed</strong>, or becomes <strong>Stunned</strong>, they become <strong>Invisible</strong> until the start of their next turn.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_pulse_laser_scourer",
+    "name": "Pulse Laser",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_last_line_seeder",
-        "name": "Last Line",
-        "origin": {
-            "type": "Class",
-            "name": "Seeder [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "Choose a mine that can be deployed with <strong>Lay Mines</strong>; the triggering character immediately detonates a hidden mine buried under the ground of that type. This Reaction may still be used even if the Seeder is destroyed.<br>If a hostile character is aware of this trait (i.e. via <strong>Scan</strong>, or automatically when the Seeder is destroyed), they may attempt a contested <strong>Systems</strong> check against the Seeder as a <strong>quick action</strong> while the Seeder (or its wreck) is within <strong>Sensors</strong>. If that character succeeds, this trait is disabled. This check automatically succeeds against destroyed Seeders.",
-        "tags": [
-            {
-                "id": "tg_reaction"
-            },
-            {
-                "id": "tg_limited",
-                "val": "1"
-            }
-        ],
-        "trigger": "A hostile character moves within <strong>Range 3</strong> of the Seeder."
+    "locked": false,
+    "type": "Trait",
+    "effect": "When the Scourer makes an attack with the <strong>Thermal Lance</strong>, they can attack two targets at a time, dealing half damage on hit. This trait automatically <strong>Recharges</strong> whenever <strong>Cooling Module</strong> activates.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_melt_scourer",
+    "name": "Melt",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_combat_shotgun_sentinel",
-        "name": "Combat Shotgun",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [
-            {
-                "id": "tg_reliable",
-                "val": "{2/3/4}"
-            }
-        ],
-        "weapon_type": "Main CQB",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ],
+    "locked": false,
+    "type": "System",
+    "effect": "The Scourer makes a ranged attack against an object, deployable or <strong>Drone</strong> within <strong>Range 10</strong>, dealing <strong>20 AP Energy damage</strong> on a success. On hit, all characters within a <strong>Burst 2</strong> radius of the target are splashed with molten slag, and count as being successfully hit with the <strong>Thermal Lance</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_thermal_overload_scourer",
+    "name": "Thermal Overload",
+    "origin": {
+      "type": "Class",
+      "name": "Scourer [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "If the <strong>Cooling Module</strong> does not activate at the start of the Scourer's turn, the <strong>Thermal Lance</strong> gains <strong>+4 Range</strong>, and on hit all other characters in a <strong>Burst 1</strong> area around the target take <strong>{3/4/5} Burn</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_marker_rifle_scout",
+    "name": "Marker Rifle",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_smart"
+      }
+    ],
+    "weapon_type": "Main Rifle",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ],
+    "damage": [],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "on_hit": "Target receives <strong>Lock On</strong>, and they become <strong>Shredded</strong> until the end of their next turn."
+  },
+  {
+    "id": "npc-rebake_npcf_sight_scout",
+    "name": "Sight",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Scout ignores <strong>Hidden</strong> and <strong>Invisible</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_rebound_scan_scout",
+    "name": "Rebound Scan",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Scout makes a tech attack against a target in Sensors. On a success, the target and all hostile characters within <strong>Range 3</strong> of the target lose <strong>Hidden</strong> and <strong>Invisible</strong> and can't regain either status or benefit from any cover until the start of the Scout's next turn.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 4
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      2,
+      3,
+      4
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_cloaking_field_scout",
+    "name": "Cloaking Field",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Scout generates a <strong>Burst 3</strong> cloaking field that lasts until the end of their next turn. The Scout and allied characters within the affected area are <strong>Invisible</strong>, but the Scout is <strong>Immobilized</strong> while it is active.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_spotter_scout",
+    "name": "Spotter",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "While adjacent to the Scout, allied characters gain <strong>+1 Accuracy</strong> on all attack rolls.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_scout_drone_scout",
+    "name": "Scout Drone",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "<strong>Scout Drone</strong> (<strong>Size</strong> 1/2, <strong>HP</strong> {5/8/10}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags</strong>: Drone)<br>The Scout deploys the drone to a free space within <strong>Sensors</strong> The drone creates a <strong>Burst 2</strong> perimeter, within which characters cannot become <strong>Invisible</strong> or <strong>Hide</strong>, and lose those conditions if they have them. The Scout and all allied characters also gain <strong>+1 Accuracy</strong> when attacking characters within the affected area. The drone can be deployed to a new location as a protocol.",
+    "tags": [
+      {
+        "id": "tg_drone"
+      },
+      {
+        "id": "tg_limited",
+        "val": 1
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_orbital_strike_scout",
+    "name": "Orbital Strike",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Scout chooses a space on the ground, within line of sight and <strong>Range 20</strong>; all characters know that it has been chosen. The Scout calls in an orbital bombardment that hits at the end of the next round, creating a <strong>Burst 2</strong> explosion. Characters in the affected area must make <strong>Agility</strong> saves. On a fail, they take <strong>{12/16/20} Energy damage</strong> and are knocked <strong>Prone</strong>. On a pass, they take half damage and remain standing.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_expose_weakness_scout",
+    "name": "Expose Weakness",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "Characters that are successfully attacked with the <strong>Marker Rifle</strong> gain a <strong>Scout's Mark</strong>. Only one character can be marked this way at a time, and marking another character clears any marks from the last one. The next time an ally successfully hits a character with a <strong>Scout's Mark</strong>, they may consume the mark to choose one of the following:<ul><li>The Target takes <strong>+1d6 bonus damage</strong>.</li><li>The target is knocked <strong>Prone</strong>.</li><li>The target only has line of sight to adjacent spaces until the end of their next turn</li><ul>",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_pathfinder_scout",
+    "name": "Pathfinder",
+    "origin": {
+      "type": "Class",
+      "name": "Scout [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "<strong>1/round</strong>, whenever the Scout successfully attacks with the <strong>Marker Rifle</strong>, an allied character within <strong>Sensors</strong> and line of sight can move up to their <strong>Speed</strong> as a Reaction.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_grav_grenade_launcher_seeder",
+    "name": "Grav-Grenade Launcher",
+    "origin": {
+      "type": "Class",
+      "name": "Seeder [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_arcing"
+      }
+    ],
+    "weapon_type": "Main Launcher",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "Explosive",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    6,
-                    8,
-                    10
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 5
-            },
-            {
-                "type": "Threat",
-                "val": 3
-            }
-        ],
-        "on_hit": ""
+          2,
+          3,
+          4
+        ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 8
+      },
+      {
+        "type": "Blast",
+        "val": 1
+      }
+    ],
+    "on_hit": "Targets are pulled <strong>1 space</strong> in a direction of the Seeder's choice."
+  },
+  {
+    "id": "npc-rebake_npcf_lay_mines_seeder",
+    "name": "Lay Mines",
+    "origin": {
+      "type": "Class",
+      "name": "Seeder [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_retractable_sword_sentinel",
-        "name": "Retractable Sword",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "",
-        "tags": [],
-        "weapon_type": "Main Melee",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+    "locked": false,
+    "type": "System",
+    "effect": "The Seeder deploys one of the mines below in a free space within <strong>Range 3</strong>. Once deployed, the Seeder’s mines detonate when a hostile character moves adjacent to them, creating a <strong>Burst 1</strong> explosion that affects both allied and hostile characters.<ul><li><strong>Sealant Mine</strong>: Characters in the area must pass a <strong>Hull</strong> save or become <strong>Immobilized</strong> until the end of their next turn, then <strong>Slowed</strong> until the end of their subsequent turn.</li><li><strong>Explosive Mine</strong>: Characters in the area must pass an <strong>Agility</strong> save or take <strong>8/12/16 explosive damage</strong>. On a success, they take <strong>half damage</strong>.</li><li><strong>Shock Mine</strong>: Characters in the area must pass a <strong>Systems</strong> save or become <strong>Jammed</strong> until the end of their next turn, then <strong>Impaired</strong> until the end of their subsequent turn.</li><li><strong>Thermite Mine</strong>: Characters in the area must pass an <strong>Engineering</strong> save or take 4/5/6 Heat and have only line of sight to adjacent spaces until the end of their next turn. On a success, they take <strong>half Heat only</strong>.</li></ul><br>The Seeder may have up to <strong>three mines</strong> deployed at a time; if they deploy another mine, one of their currently deployed mines of their choice disarms and deactivates. When the Seeder is destroyed, its deployed mines remain active, but now detonate whenever any character moves adjacent to them.",
+    "tags": [
+      {
+        "id": "tg_mine"
+      },
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_turn",
+        "val": 1
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_safety_net_seeder",
+    "name": "Safety Net",
+    "origin": {
+      "type": "Class",
+      "name": "Seeder [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Seeder never triggers or sets off <strong>Mines</strong> or other proximity-based systems unless it chooses to do so.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_grav_spike_seeder",
+    "name": "Grav Spike",
+    "origin": {
+      "type": "Class",
+      "name": "Seeder [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "A character within line of sight and <strong>Range 5</strong> must succeed on a <strong>Systems</strong> save, or a grav spike attaches itself to them. The Seeder can detonate all grav spikes as a <strong>protocol</strong>, causing targets to automatically take <strong>4/5/6 AP explosive damage</strong> and be pulled <strong>3 spaces</strong> in a direction of their choice. Characters can remove a grav spike from themselves by passing a <strong>Systems</strong> save as a <strong>quick action</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_FASCAM_seeder",
+    "name": "FASCAM",
+    "origin": {
+      "type": "Class",
+      "name": "Seeder [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "System",
+    "effect": "The Seeder launches a rocket which scatters a field of explosive micromines over a <strong>Blast 3</strong> area within <strong>Sensors</strong>; this area can overlap with obstructions (like cover or terrain) when deployed, but not characters. Characters who enter this area or attempt to move while within it for the first time in a round must pass a <strong>Systems</strong> save or step on a mine, taking <strong>5/6/7 explosive damage</strong>. Only one field of micromines can exist at a time, and if a new one is created, the previous one deactivates.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_speed_deployer_seeder",
+    "name": "Speed Deployer",
+    "origin": {
+      "type": "Class",
+      "name": "Seeder [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "<strong>Lay Mines</strong> may now deploy up to <strong>three mines</strong> at a time instead of just one. If the Seeder deploys more than one mine at a time this way, this trait can't be used again until one of its mines detonates or is disarmed.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_hopping_mines_seeder",
+    "name": "Hopping Mines",
+    "origin": {
+      "type": "Class",
+      "name": "Seeder [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "Mines deployed with <strong>Lay Mines</strong> also activate when hostile characters fly or move over or adjacent to them, up to <strong>10 spaces</strong> high. The mines jump up to <strong>10 spaces</strong>, detonating and affecting all characters within their area.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_last_line_seeder",
+    "name": "Last Line",
+    "origin": {
+      "type": "Class",
+      "name": "Seeder [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Reaction",
+    "effect": "Choose a mine that can be deployed with <strong>Lay Mines</strong>; the triggering character immediately detonates a hidden mine buried under the ground of that type. This Reaction may still be used even if the Seeder is destroyed.<br>If a hostile character is aware of this trait (i.e. via <strong>Scan</strong>, or automatically when the Seeder is destroyed), they may attempt a contested <strong>Systems</strong> check against the Seeder as a <strong>quick action</strong> while the Seeder (or its wreck) is within <strong>Sensors</strong>. If that character succeeds, this trait is disabled. This check automatically succeeds against destroyed Seeders.",
+    "tags": [
+      {
+        "id": "tg_reaction"
+      },
+      {
+        "id": "tg_limited",
+        "val": "1"
+      }
+    ],
+    "trigger": "A hostile character moves within <strong>Range 3</strong> of the Seeder."
+  },
+  {
+    "id": "npc-rebake_npcf_combat_shotgun_sentinel",
+    "name": "Combat Shotgun",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [
+      {
+        "id": "tg_reliable",
+        "val": "{2/3/4}"
+      }
+    ],
+    "weapon_type": "Main CQB",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    4,
-                    5,
-                    6
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 1
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_eye_of_midnight_sentinel",
-        "name": "Eye of Midnight",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Sentinel becomes <strong>Slowed</strong>, but can take the <strong>Overwatch</strong> Reaction <strong>1/turn</strong> instead of <strong>1/round</strong>. Additionally, they may attack with <strong>Overwatch</strong> using the <strong>Combat Shotgun</strong> when hostile characters enter, leave, or exit spaces within their <strong>Threat</strong> no matter whether they started their movement there. Once activated, this effect lasts until it is deactivated as a <strong>quick action</strong>.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
+          6,
+          8,
+          10
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      },
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_retractable_sword_sentinel",
+    "name": "Retractable Sword",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_guardian_sentinel",
-        "name": "Guardian",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Allied characters can use the Sentinel for <strong>hard cover</strong>.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_punisher_ammunition_sentinel",
-        "name": "Punisher Ammunition",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Characters damaged by the Sentinel’s <strong>Overwatch</strong> attacks also become <strong>Slowed</strong> until the end of their next turn.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_bodyguard_sentinel",
-        "name": "Bodyguard",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Sentinel chooses an allied character within <strong>Range 5</strong> as their ward and gains the <strong>Reflexive Blow</strong> Reaction, which can be taken as many times per round as it is triggered",
-        "tags": [
-            {
-                "id": "tg_protocol"
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": ""
-    },
-    {
-        "id": "npc-rebake_npcf_reflexive_blow_sentinel",
-        "name": "Reflexive Blow",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Sentinel may move their <strong>Speed</strong> towards their ward by the most direct route possible, then attack the inciting character with <strong>Overwatch</strong>. This Reaction interrupts and resolves before the triggering action, ignores engagement, and doesn’t provoke reactions.",
-        "tags": [
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "Someone attacks the Sentinel’s ward."
-    },
-    {
-        "id": "npc-rebake_npcf_wrath_lock_sentinel",
-        "name": "Wrath-Lock",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Sentinel may <strong>Boost</strong> towards the triggering character, and the triggering character gains <strong>Lock On</strong>.",
-        "tags": [
-            {
-                "id": "tg_reaction"
-            },
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ],
-        "trigger": "A hostile character in line of sight moves."
-    },
-    {
-        "id": "npc-rebake_npcf_impaler_sentinel",
-        "name": "Impaler",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "When the Sentinel hits with <strong>Overwatch</strong>, their target must pass a <strong>Hull</strong> save or become <strong>Immobilized</strong> and <strong>Jammed</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            }
-        ]
-    },
-    {
-        "id": "npc-rebake_npcf_marker_shells_sentinel",
-        "name": "Marker Shells",
-        "origin": {
-            "type": "Class",
-            "name": "Sentinel [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Characters damaged by the Sentinel's <strong>Combat Shotgun</strong> (including <strong>Reliable</strong> damage) gain a <strong>Sentinel's Mark</strong>. Whenever the Sentinel makes an <strong>Overwatch</strong> attack against a marked character, they gain <strong>+1 Accuracy</strong> and ignore <strong>Invisible</strong>. All <strong>Sentinel's Marks</strong> are cleared at the start of the Sentinel's turn.",
-        "tags": []
-    },
-    {
-        "id": "npc-rebake_npcf_anti_materiel_rifle_sniper",
-        "name": "Anti-Materiel Rifle",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "This weapon does not gain <strong>Accuracy</strong> from attacking <strong>Prone</strong> targets",
-        "tags": [
-            {
-                "id": "tg_ap"
-            },
-            {
-                "id": "tg_ordnance"
-            },
-            {
-                "id": "tg_loading"
-            }
-        ],
-        "weapon_type": "Superheavy Rifle",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+    "locked": false,
+    "type": "Weapon",
+    "effect": "",
+    "tags": [],
+    "weapon_type": "Main Melee",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    10,
-                    15,
-                    20
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 20
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_snipers_mark_sniper",
-        "name": "Sniper’s Mark",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "A character within <strong>Range 20</strong> and line of sight gains the <strong>Sniper’s Mark</strong>. Against targets with the <strong>Sniper’s Mark</strong>, the sniper gains <strong>+1 Accuracy</strong> on attacks with the <strong>Anti-Materiel Rifle</strong> and may choose to deal <strong>1 structure damage</strong> instead of its usual damage on hit.<br>Characters know when they have the <strong>Sniper's Mark</strong> They ignore its effects if they are in cover or <strong>Prone</strong>. On their turn, characters with the <strong>Sniper's Mark</strong> may drop <strong>Prone</strong> as a <strong>free action</strong><br>The Sniper can only mark one character at a time, but can transfer the <strong>Sniper's Mark</strong> to another character within <strong>Range 20</strong> and line of sight as a <strong>full action</strong>, or whenever the sniper reloads the <strong>Anti-Material Rifle</strong>.",
-        "tags": [
-            {
-                "id": "tg_full_action"
-            }
+          4,
+          5,
+          6
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_eye_of_midnight_sentinel",
+    "name": "Eye of Midnight",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_climber_sniper",
-        "name": "Climber",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Sniper treats all solid surfaces as flat ground for the purposes of movement; they can move and remain stationary on any surface without penalty, including overhanging and vertical surfaces, although they begin to fall if knocked <strong>Prone</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "The Sentinel becomes <strong>Slowed</strong>, but can take the <strong>Overwatch</strong> Reaction <strong>1/turn</strong> instead of <strong>1/round</strong>. Additionally, they may attack with <strong>Overwatch</strong> using the <strong>Combat Shotgun</strong> when hostile characters enter, leave, or exit spaces within their <strong>Threat</strong> no matter whether they started their movement there. Once activated, this effect lasts until it is deactivated as a <strong>quick action</strong>.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_guardian_sentinel",
+    "name": "Guardian",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_sharpshooter_sniper",
-        "name": "Sharpshooter",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Sniper can attempt a called shot before attacking characters with the <strong>Sniper's Mark</strong> using the <strong>Anti-Materiel Rifle</strong>. This attack functions as usual, with an additional effect on a successful attack.<br>The Sniper may choose from the following:<ul><li><strong>Target Head:</strong> Targets must pass a <strong>Hull</strong> save or only be able to draw line of sight to adjacent spaces until the end of their next turn.</li><li><strong>Target Legs:</strong> Targets must pass an <strong>Agility</strong> save or be <strong>Immobilized</strong> until the end of their next turn.</li><li><strong>Target Hardpoints</strong>: Targets must pass a <strong>Systems</strong> save or become <strong>Jammed</strong> until the end of their next turn.</li><li><strong>Target Body:</strong> Targets must pass an <strong>Engineering</strong> save or become <strong>Shredded</strong> until the end of their next turn.</li></ul>",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "Allied characters can use the Sentinel for <strong>hard cover</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_punisher_ammunition_sentinel",
+    "name": "Punisher Ammunition",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_shift_sights_sniper",
-        "name": "Shift Sights",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Sniper may transfer the <strong>Sniper's Mark</strong> to a character within <strong>Range 2</strong> of the currently marked character.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_protocol"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "Characters damaged by the Sentinel’s <strong>Overwatch</strong> attacks also become <strong>Slowed</strong> until the end of their next turn.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_bodyguard_sentinel",
+    "name": "Bodyguard",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_defensive_grapple_sniper",
-        "name": "Defensive Grapple",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Sniper uses a grappling hook to <strong>fly</strong> to any free space that ends on an object or surface within <strong>Range 5</strong>, including vertical and overhanging surfaces. The Sniper also gains the <strong>Relocation</strong> reaction.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 4
-            },
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": ""
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Sentinel chooses an allied character within <strong>Range 5</strong> as their ward and gains the <strong>Reflexive Blow</strong> Reaction, which can be taken as many times per round as it is triggered",
+    "tags": [
+      {
+        "id": "tg_protocol"
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": ""
+  },
+  {
+    "id": "npc-rebake_npcf_reflexive_blow_sentinel",
+    "name": "Reflexive Blow",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_relocation_sniper",
-        "name": "Relocation",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Sniper uses Defensive Grapple.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "An hostile character in line of sight moves."
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Sentinel may move their <strong>Speed</strong> towards their ward by the most direct route possible, then attack the inciting character with <strong>Overwatch</strong>. This Reaction interrupts and resolves before the triggering action, ignores engagement, and doesn’t provoke reactions.",
+    "tags": [
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "Someone attacks the Sentinel’s ward."
+  },
+  {
+    "id": "npc-rebake_npcf_wrath_lock_sentinel",
+    "name": "Wrath-Lock",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_moving_target_sniper",
-        "name": "Moving Target",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Reaction",
-        "effect": "The Sniper interrupts the movement. The character must immediately stop, give up all remaining movement, and fall <strong>Prone</strong> or they gain the <strong>Sniper's Mark.</strong> <br>If they already have the <strong>Sniper's Mark</strong>, the Sniper instead may make an immediate attack against them with the <strong>Anti-Materiel Rifle</strong>.",
-        "tags": [
-            {
-                "id": "tg_round",
-                "val": 1
-            },
-            {
-                "id": "tg_reaction"
-            }
-        ],
-        "trigger": "A hostile character in line of sight and <strong>Range 20</strong> moves."
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Sentinel may <strong>Boost</strong> towards the triggering character, and the triggering character gains <strong>Lock On</strong>.",
+    "tags": [
+      {
+        "id": "tg_reaction"
+      },
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ],
+    "trigger": "A hostile character in line of sight moves."
+  },
+  {
+    "id": "npc-rebake_npcf_impaler_sentinel",
+    "name": "Impaler",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_deadeye_sniper",
-        "name": "Deadeye",
-        "origin": {
-            "type": "Class",
-            "name": "Sniper [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Sniper gets <strong>+1 Accuracy</strong> on attacks with the <strong>Anti-Materiel Rifle</strong> against characters that did not move their <strong>Speed</strong> or more during their turns.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "When the Sentinel hits with <strong>Overwatch</strong>, their target must pass a <strong>Hull</strong> save or become <strong>Immobilized</strong> and <strong>Jammed</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_marker_shells_sentinel",
+    "name": "Marker Shells",
+    "origin": {
+      "type": "Class",
+      "name": "Sentinel [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_monowire_sword_specter",
-        "name": "Monowire Sword",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "<strong>Armor</strong> is doubled against this weapon.",
-        "tags": [],
-        "weapon_type": "Main Melee",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+    "locked": false,
+    "type": "Trait",
+    "effect": "Characters damaged by the Sentinel's <strong>Combat Shotgun</strong> (including <strong>Reliable</strong> damage) gain a <strong>Sentinel's Mark</strong>. Whenever the Sentinel makes an <strong>Overwatch</strong> attack against a marked character, they gain <strong>+1 Accuracy</strong> and ignore <strong>Invisible</strong>. All <strong>Sentinel's Marks</strong> are cleared at the start of the Sentinel's turn.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_anti_materiel_rifle_sniper",
+    "name": "Anti-Materiel Rifle",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "This weapon does not gain <strong>Accuracy</strong> from attacking <strong>Prone</strong> targets",
+    "tags": [
+      {
+        "id": "tg_ap"
+      },
+      {
+        "id": "tg_ordnance"
+      },
+      {
+        "id": "tg_loading"
+      }
+    ],
+    "weapon_type": "Superheavy Rifle",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    5,
-                    6,
-                    7
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Threat",
-                "val": 2
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_prowl_specter",
-        "name": "Prowl",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Specter moves spaces equal to <strong>Speed</strong>, then becomes <strong>Hidden</strong>. This movement ignores engagement and doesn’t provoke reactions.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
+          10,
+          15,
+          20
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 20
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_snipers_mark_sniper",
+    "name": "Sniper’s Mark",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_tactical_cloak_specter",
-        "name": "Tactical Cloak",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Specter is permanently <strong>Invisible</strong>. As a <strong>Full Action</strong>, a character can engage in a contested <strong>Systems</strong> check with the Specter to attempt to disable their cloak; all characters are aware of this. The Specter must be within their Sensors for them to attempt this check. If they succeed, the Specter takes <strong>4 Heat</strong> and this trait is disabled until the end of their next turn. If they fail, that character gains <strong>Lock On</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "A character within <strong>Range 20</strong> and line of sight gains the <strong>Sniper’s Mark</strong>. Against targets with the <strong>Sniper’s Mark</strong>, the sniper gains <strong>+1 Accuracy</strong> on attacks with the <strong>Anti-Materiel Rifle</strong> and may choose to deal <strong>1 structure damage</strong> instead of its usual damage on hit.<br>Characters know when they have the <strong>Sniper's Mark</strong> They ignore its effects if they are in cover or <strong>Prone</strong>. On their turn, characters with the <strong>Sniper's Mark</strong> may drop <strong>Prone</strong> as a <strong>free action</strong><br>The Sniper can only mark one character at a time, but can transfer the <strong>Sniper's Mark</strong> to another character within <strong>Range 20</strong> and line of sight as a <strong>full action</strong>, or whenever the sniper reloads the <strong>Anti-Material Rifle</strong>.",
+    "tags": [
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_climber_sniper",
+    "name": "Climber",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_hunt_specter",
-        "name": "Hunt",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The <strong>Monowire Sword</strong> deals double damage when no other characters are adjacent to the target.",
-        "tags": []
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Sniper treats all solid surfaces as flat ground for the purposes of movement; they can move and remain stationary on any surface without penalty, including overhanging and vertical surfaces, although they begin to fall if knocked <strong>Prone</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_sharpshooter_sniper",
+    "name": "Sharpshooter",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_step_specter",
-        "name": "Step",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Specter <strong>teleports</strong> to a free space within line of sight and <strong>Range 50</strong>.",
-        "tags": [
-            {
-                "id": "tg_recharge",
-                "val": 5
-            },
-            {
-                "id": "tg_quick_action"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Sniper can attempt a called shot before attacking characters with the <strong>Sniper's Mark</strong> using the <strong>Anti-Materiel Rifle</strong>. This attack functions as usual, with an additional effect on a successful attack.<br>The Sniper may choose from the following:<ul><li><strong>Target Head:</strong> Targets must pass a <strong>Hull</strong> save or only be able to draw line of sight to adjacent spaces until the end of their next turn.</li><li><strong>Target Legs:</strong> Targets must pass an <strong>Agility</strong> save or be <strong>Immobilized</strong> until the end of their next turn.</li><li><strong>Target Hardpoints</strong>: Targets must pass a <strong>Systems</strong> save or become <strong>Jammed</strong> until the end of their next turn.</li><li><strong>Target Body:</strong> Targets must pass an <strong>Engineering</strong> save or become <strong>Shredded</strong> until the end of their next turn.</li></ul>",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_shift_sights_sniper",
+    "name": "Shift Sights",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_drain_systems_specter",
-        "name": "Drain Systems",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Specter makes a tech attack against an adjacent character. On a success, the target becomes <strong>Stunned</strong>. This effect lasts until a character other than the Specter starts their turn adjacent to the target or moves adjacent to the target.",
-        "tags": [
-            {
-                "id": "tg_full_tech"
-            }
-        ],
-        "tech_type": "Full",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Sniper may transfer the <strong>Sniper's Mark</strong> to a character within <strong>Range 2</strong> of the currently marked character.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_protocol"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_defensive_grapple_sniper",
+    "name": "Defensive Grapple",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_lure_specter",
-        "name": "Lure",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Specter makes a tech attack against a character within <strong>Sensors</strong>. On a success, that character must choose: move their <strong>Speed</strong> towards the Specter, or become <strong>Slowed</strong> and <strong>Impaired</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 4
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            1,
-            2,
-            3
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "The Sniper uses a grappling hook to <strong>fly</strong> to any free space that ends on an object or surface within <strong>Range 5</strong>, including vertical and overhanging surfaces. The Sniper also gains the <strong>Relocation</strong> reaction.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 4
+      },
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": ""
+  },
+  {
+    "id": "npc-rebake_npcf_relocation_sniper",
+    "name": "Relocation",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_ghostwalk_specter",
-        "name": "Ghostwalk",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Specter becomes <strong>Intangible</strong> until the start of their next turn and moves spaces equal to their <strong>Speed</strong>. At the start of their next turn, their next attack with the <strong>Monowire Sword</strong> gains <strong>+1 Accuracy</strong> and deals <strong>+1d6 bonus damage</strong> on a critical hit. This bonus damage is not doubled.",
-        "tags": [
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Sniper uses Defensive Grapple.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "An hostile character in line of sight moves."
+  },
+  {
+    "id": "npc-rebake_npcf_moving_target_sniper",
+    "name": "Moving Target",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_machine_pistol_specter",
-        "name": "Machine Pistol",
-        "origin": {
-            "type": "Class",
-            "name": "Specter [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Weapon",
-        "effect": "The Specter can move <strong>2 spaces</strong> in any direction before or after attacking with this weapon. This movement ignores engagement and doesn't provoke reactions.",
-        "tags": [],
-        "weapon_type": "Auxiliary CQB",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
+    "locked": false,
+    "type": "Reaction",
+    "effect": "The Sniper interrupts the movement. The character must immediately stop, give up all remaining movement, and fall <strong>Prone</strong> or they gain the <strong>Sniper's Mark.</strong> <br>If they already have the <strong>Sniper's Mark</strong>, the Sniper instead may make an immediate attack against them with the <strong>Anti-Materiel Rifle</strong>.",
+    "tags": [
+      {
+        "id": "tg_round",
+        "val": 1
+      },
+      {
+        "id": "tg_reaction"
+      }
+    ],
+    "trigger": "A hostile character in line of sight and <strong>Range 20</strong> moves."
+  },
+  {
+    "id": "npc-rebake_npcf_deadeye_sniper",
+    "name": "Deadeye",
+    "origin": {
+      "type": "Class",
+      "name": "Sniper [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Sniper gets <strong>+1 Accuracy</strong> on attacks with the <strong>Anti-Materiel Rifle</strong> against characters that did not move their <strong>Speed</strong> or more during their turns.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_monowire_sword_specter",
+    "name": "Monowire Sword",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "<strong>Armor</strong> is doubled against this weapon.",
+    "tags": [],
+    "weapon_type": "Main Melee",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
         "damage": [
-            {
-                "type": "kinetic",
-                "damage": [
-                    3,
-                    4,
-                    5
-                ]
-            }
-        ],
-        "range": [
-            {
-                "type": "Range",
-                "val": 5
-            },
-            {
-                "type": "Threat",
-                "val": 3
-            }
-        ],
-        "on_hit": ""
-    },
-    {
-        "id": "npc-rebake_npcf_sealant_gun_support",
-        "name": "Sealant Gun",
-        "origin": {
-            "type": "Class",
-            "name": "Support [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Support chooses a character within line of sight and <strong>Range 5</strong>, allied or hostile:<ul><li><strong>Allied:</strong> The target clears all <strong>Burn</strong>, but becomes <strong>Slowed</strong> until the end of their next turn.</li><li><strong>Hostile:</strong> The target must pass an <strong>Agility</strong> save or become <strong>Slowed</strong> until the end of their next turn. Succeed of fail, a <strong>Burst 1</strong> area around them becomes <strong>difficult terrain</strong> for the rest of the scene.</li></ul>",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            }
+          5,
+          6,
+          7
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 2
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_prowl_specter",
+    "name": "Prowl",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_restock_drone_support",
-        "name": "Restock Drone",
-        "origin": {
-            "type": "Class",
-            "name": "Support [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "Restock Drone (Size 1/2, HP {5/8/10}, Evasion {10/10/10}, E-Defense {10/10/10}, Tags: Drone)<br>This drone can be deployed hovering in a space within <strong>Range 5</strong>. The next time an allied character moves through or next to the drone, it clamps on and discharges its reserves, letting them either regain {5/8/10} <strong>HP</strong> or reload one <strong>Loading</strong> weapon.",
-        "tags": [
-            {
-                "id": "tg_drone"
-            },
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 5
-            }
+    "locked": false,
+    "type": "System",
+    "effect": "The Specter moves spaces equal to <strong>Speed</strong>, then becomes <strong>Hidden</strong>. This movement ignores engagement and doesn’t provoke reactions.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_tactical_cloak_specter",
+    "name": "Tactical Cloak",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Specter is permanently <strong>Invisible</strong>. As a <strong>Full Action</strong>, a character can engage in a contested <strong>Systems</strong> check with the Specter to attempt to disable their cloak; all characters are aware of this. The Specter must be within their Sensors for them to attempt this check. If they succeed, the Specter takes <strong>4 Heat</strong> and this trait is disabled until the end of their next turn. If they fail, that character gains <strong>Lock On</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_hunt_specter",
+    "name": "Hunt",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": true
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The <strong>Monowire Sword</strong> deals double damage when no other characters are adjacent to the target.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_step_specter",
+    "name": "Step",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Specter <strong>teleports</strong> to a free space within line of sight and <strong>Range 50</strong>.",
+    "tags": [
+      {
+        "id": "tg_recharge",
+        "val": 5
+      },
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_drain_systems_specter",
+    "name": "Drain Systems",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Specter makes a tech attack against an adjacent character. On a success, the target becomes <strong>Stunned</strong>. This effect lasts until a character other than the Specter starts their turn adjacent to the target or moves adjacent to the target.",
+    "tags": [
+      {
+        "id": "tg_full_tech"
+      }
+    ],
+    "tech_type": "Full",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_lure_specter",
+    "name": "Lure",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Specter makes a tech attack against a character within <strong>Sensors</strong>. On a success, that character must choose: move their <strong>Speed</strong> towards the Specter, or become <strong>Slowed</strong> and <strong>Impaired</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 4
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      1,
+      2,
+      3
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_ghostwalk_specter",
+    "name": "Ghostwalk",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Specter becomes <strong>Intangible</strong> until the start of their next turn and moves spaces equal to their <strong>Speed</strong>. At the start of their next turn, their next attack with the <strong>Monowire Sword</strong> gains <strong>+1 Accuracy</strong> and deals <strong>+1d6 bonus damage</strong> on a critical hit. This bonus damage is not doubled.",
+    "tags": [
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_machine_pistol_specter",
+    "name": "Machine Pistol",
+    "origin": {
+      "type": "Class",
+      "name": "Specter [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Weapon",
+    "effect": "The Specter can move <strong>2 spaces</strong> in any direction before or after attacking with this weapon. This movement ignores engagement and doesn't provoke reactions.",
+    "tags": [],
+    "weapon_type": "Auxiliary CQB",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "damage": [
+      {
+        "type": "kinetic",
+        "damage": [
+          3,
+          4,
+          5
         ]
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      },
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "on_hit": ""
+  },
+  {
+    "id": "npc-rebake_npcf_sealant_gun_support",
+    "name": "Sealant Gun",
+    "origin": {
+      "type": "Class",
+      "name": "Support [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_nano-repair_cloud_support",
-        "name": "Nano-Repair Cloud",
-        "origin": {
-            "type": "Class",
-            "name": "Support [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "While they are adjacent to the Support, allied characters roll twice on all saves and mech skill checks and choose the higher result.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "The Support chooses a character within line of sight and <strong>Range 5</strong>, allied or hostile:<ul><li><strong>Allied:</strong> The target clears all <strong>Burn</strong>, but becomes <strong>Slowed</strong> until the end of their next turn.</li><li><strong>Hostile:</strong> The target must pass an <strong>Agility</strong> save or become <strong>Slowed</strong> until the end of their next turn. Succeed of fail, a <strong>Burst 1</strong> area around them becomes <strong>difficult terrain</strong> for the rest of the scene.</li></ul>",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_restock_drone_support",
+    "name": "Restock Drone",
+    "origin": {
+      "type": "Class",
+      "name": "Support [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_desant_hardpoints_support",
-        "name": "Desant Hardpoints",
-        "origin": {
-            "type": "Class",
-            "name": "Support [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Adjacent, non-<strong>Immobilized</strong> allied characters can climb onto the Support as a <strong>quick action.</strong> While riding, they occupy the same space, move when the Support moves (even if they're <strong>Slowed</strong>), and benefit from <strong>soft cover.</strong> If they or the Support are knocked <strong>Prone</strong>, <strong>Stunned</strong>, <strong>Immobilized</strong>, or destroyed, they land <strong>Prone</strong> in adjacent spaces. Riders can climb down as part of any movement away.<br>The Support can carry one <strong>Squad</strong> or characters whose own combined <strong>Size</strong> is less than its own.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "Restock Drone (Size 1/2, HP {5/8/10}, Evasion {10/10/10}, E-Defense {10/10/10}, Tags: Drone)<br>This drone can be deployed hovering in a space within <strong>Range 5</strong>. The next time an allied character moves through or next to the drone, it clamps on and discharges its reserves, letting them either regain {5/8/10} <strong>HP</strong> or reload one <strong>Loading</strong> weapon.",
+    "tags": [
+      {
+        "id": "tg_drone"
+      },
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 5
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_nano-repair_cloud_support",
+    "name": "Nano-Repair Cloud",
+    "origin": {
+      "type": "Class",
+      "name": "Support [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_remote_cloud_support",
-        "name": "Remote Cloud",
-        "origin": {
-            "type": "Class",
-            "name": "Support [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "The Support releases a <strong>Blast 2</strong> nanite cloud within <strong>Range 5</strong>. Allied characters within this area gain <strong>+1 Accuracy</strong> on all checks and saves. This effect does not stack with other <strong>Remote Clouds</strong>. The cloud lasts until the end of the scene, until the Support is destroyed, or until the Support uses this system again.",
-        "tags": [
-            {
-                "id": "tg_quick_action"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 5
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "While they are adjacent to the Support, allied characters roll twice on all saves and mech skill checks and choose the higher result.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_desant_hardpoints_support",
+    "name": "Desant Hardpoints",
+    "origin": {
+      "type": "Class",
+      "name": "Support [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_remote_reboot_support",
-        "name": "Remote Reboot",
-        "origin": {
-            "type": "Class",
-            "name": "Support [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Support clears any two of the following <strong>conditions</strong> currently affecting an allied character in <strong>Range 5</strong>: <strong>Impaired</strong>, <strong>Jammed</strong>, <strong>Stunned</strong>, <strong>Slowed</strong>. That character may then either move up to their <strong>Speed</strong> or stand from <strong>Prone</strong>.",
-        "tags": [
-            {
-                "id": "tg_full_action"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 6
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "Adjacent, non-<strong>Immobilized</strong> allied characters can climb onto the Support as a <strong>quick action.</strong> While riding, they occupy the same space, move when the Support moves (even if they're <strong>Slowed</strong>), and benefit from <strong>soft cover.</strong> If they or the Support are knocked <strong>Prone</strong>, <strong>Stunned</strong>, <strong>Immobilized</strong>, or destroyed, they land <strong>Prone</strong> in adjacent spaces. Riders can climb down as part of any movement away.<br>The Support can carry one <strong>Squad</strong> or characters whose own combined <strong>Size</strong> is less than its own.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_remote_cloud_support",
+    "name": "Remote Cloud",
+    "origin": {
+      "type": "Class",
+      "name": "Support [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_empowered_cloud_support",
-        "name": "Empowered Cloud",
-        "origin": {
-            "type": "Class",
-            "name": "Support [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "When they start their turn adjacent to the Support, allied characters may clear one <strong>Condition</strong>. The Support takes <strong>4 Heat</strong> for each <strong>condition</strong> cleared this way.",
-        "tags": []
+    "locked": false,
+    "type": "System",
+    "effect": "The Support releases a <strong>Blast 2</strong> nanite cloud within <strong>Range 5</strong>. Allied characters within this area gain <strong>+1 Accuracy</strong> on all checks and saves. This effect does not stack with other <strong>Remote Clouds</strong>. The cloud lasts until the end of the scene, until the Support is destroyed, or until the Support uses this system again.",
+    "tags": [
+      {
+        "id": "tg_quick_action"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 5
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_remote_reboot_support",
+    "name": "Remote Reboot",
+    "origin": {
+      "type": "Class",
+      "name": "Support [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_latch_drone_support",
-        "name": "Latch Drone",
-        "origin": {
-            "type": "Class",
-            "name": "Support [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "System",
-        "effect": "Latch Drone (Size 1/2, HP {5/8/10}, Evasion {10/10/10}, E-Defense {10/10/10}, Tags: Drone)<br>This self-deploying drone clamps onto a character within <strong>Range 5</strong>, occupying the same space and moving with them. While the drone is attached, the target regains {5/8/10} HP at the start of each of their turns and gains <strong>+1 Accuracy</strong> on all checks, saves, and attacks. Enemies can target the drone with attacks. Only one <strong>Latch Drone</strong> can be deployed at a time, and if a new one is deployed, or the Support is destroyed, the old one disintegrates and is destroyed.",
-        "tags": [
-            {
-                "id": "tg_drone"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 6
-            },
-            {
-                "id": "tg_full_action"
-            }
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Support clears any two of the following <strong>conditions</strong> currently affecting an allied character in <strong>Range 5</strong>: <strong>Impaired</strong>, <strong>Jammed</strong>, <strong>Stunned</strong>, <strong>Slowed</strong>. That character may then either move up to their <strong>Speed</strong> or stand from <strong>Prone</strong>.",
+    "tags": [
+      {
+        "id": "tg_full_action"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 6
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_empowered_cloud_support",
+    "name": "Empowered Cloud",
+    "origin": {
+      "type": "Class",
+      "name": "Support [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_tear_down_witch",
-        "name": "Tear Down",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>{1/2/3} Heat</strong> immediately, and then a further <strong>4 Heat</strong> at the start of the Witch’s next turn; this effect does not stack. If an affected target or an adjacent hostile character takes the <strong>Stabilize</strong> action, they can choose to end the effect of this system in place of cooling their mech.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "When they start their turn adjacent to the Support, allied characters may clear one <strong>Condition</strong>. The Support takes <strong>4 Heat</strong> for each <strong>condition</strong> cleared this way.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_latch_drone_support",
+    "name": "Latch Drone",
+    "origin": {
+      "type": "Class",
+      "name": "Support [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_blind_witch",
-        "name": "Blind",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>{2/3/4} Heat</strong> and must pass a <strong>Systems</strong> save or only be able to draw line of sight to adjacent spaces until the end of their next turn. If the target succeeds, they become <strong>Impaired</strong> until the end of their next turn instead.",
-        "tags": [
-            {
-                "id": "tg_full_tech"
-            }
-        ],
-        "tech_type": "Full",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ]
+    "locked": false,
+    "type": "System",
+    "effect": "Latch Drone (Size 1/2, HP {5/8/10}, Evasion {10/10/10}, E-Defense {10/10/10}, Tags: Drone)<br>This self-deploying drone clamps onto a character within <strong>Range 5</strong>, occupying the same space and moving with them. While the drone is attached, the target regains {5/8/10} HP at the start of each of their turns and gains <strong>+1 Accuracy</strong> on all checks, saves, and attacks. Enemies can target the drone with attacks. Only one <strong>Latch Drone</strong> can be deployed at a time, and if a new one is deployed, or the Support is destroyed, the old one disintegrates and is destroyed.",
+    "tags": [
+      {
+        "id": "tg_drone"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 6
+      },
+      {
+        "id": "tg_full_action"
+      }
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_tear_down_witch",
+    "name": "Tear Down",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_predatory_logic_witch",
-        "name": "Predatory Logic",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Witch makes a tech attack against a hostile character within <strong>Sensors</strong>. On a success, the target immediately uses a <strong>non-Superheavy</strong> weapon chosen by the Witch to attack a character within <strong>Range</strong> also chosen by the Witch as a reaction. If the target takes the <strong>Brace</strong> reaction in response to this tech attack, they ignore the effect of this system; characters in the <strong>Danger Zone</strong> can't take the <strong>Brace</strong> reaction against this attack.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            },
-            {
-                "id": "tg_recharge",
-                "val": 6
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ]
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>{1/2/3} Heat</strong> immediately, and then a further <strong>4 Heat</strong> at the start of the Witch’s next turn; this effect does not stack. If an affected target or an adjacent hostile character takes the <strong>Stabilize</strong> action, they can choose to end the effect of this system in place of cooling their mech.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_blind_witch",
+    "name": "Blind",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_blur_witch",
-        "name": "Blur",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": true
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The Witch counts as <strong>Invisible</strong> against characters in the <strong>Danger Zone</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>{2/3/4} Heat</strong> and must pass a <strong>Systems</strong> save or only be able to draw line of sight to adjacent spaces until the end of their next turn. If the target succeeds, they become <strong>Impaired</strong> until the end of their next turn instead.",
+    "tags": [
+      {
+        "id": "tg_full_tech"
+      }
+    ],
+    "tech_type": "Full",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_predatory_logic_witch",
+    "name": "Predatory Logic",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_dark_cloud_witch",
-        "name": "Dark Cloud",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "The additional Heat dealt by <strong>Tear Down</strong> on the Witch’s next turn increases to <strong>7 Heat</strong> if the target is in the <strong>Danger Zone</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Witch makes a tech attack against a hostile character within <strong>Sensors</strong>. On a success, the target immediately uses a <strong>non-Superheavy</strong> weapon chosen by the Witch to attack a character within <strong>Range</strong> also chosen by the Witch as a reaction. If the target takes the <strong>Brace</strong> reaction in response to this tech attack, they ignore the effect of this system; characters in the <strong>Danger Zone</strong> can't take the <strong>Brace</strong> reaction against this attack.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      },
+      {
+        "id": "tg_recharge",
+        "val": 6
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_blur_witch",
+    "name": "Blur",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": true
     },
-    {
-        "id": "npc-rebake_npcf_chain_witch",
-        "name": "Chain",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the Witch chains their target’s systems to a space within <strong>Range 3</strong> of the target. If the target moves more than <strong>3 spaces</strong> from that point (voluntarily or otherwise), they take <strong>{2/3/4} Heat</strong> and become <strong>Jammed</strong> until the end of their next turn, but the effect ends. Otherwise, they are chained until the Witch is destroyed or <strong>Stunned</strong>, or until the end of the scene.",
-        "tags": [
-            {
-                "id": "tg_quick_tech"
-            }
-        ],
-        "tech_type": "Quick",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The Witch counts as <strong>Invisible</strong> against characters in the <strong>Danger Zone</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_dark_cloud_witch",
+    "name": "Dark Cloud",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_petrify_witch",
-        "name": "Petrify",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target becomes <strong>Slowed</strong> until the end of their next turn. When <strong>Slowed</strong> expires, they then become <strong>Immobilized</strong> until the end of their next turn. When <strong>Immobilized</strong> expires, they then become <strong>Stunned</strong> until the end of their next turn. Clearing any of these conditions (e.g. with <strong>Stabilize</strong>) prevents further conditions from occurring on subsequent turns.\n\nThis system can't be used again while it is currently in the process of affecting a character, and it can only be used 1/scene on each character.",
-        "tags": [
-            {
-                "id": "tg_full_tech"
-            }
-        ],
-        "tech_type": "Full",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ]
+    "locked": false,
+    "type": "Trait",
+    "effect": "The additional Heat dealt by <strong>Tear Down</strong> on the Witch’s next turn increases to <strong>7 Heat</strong> if the target is in the <strong>Danger Zone</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_chain_witch",
+    "name": "Chain",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_pain_transference_witch",
-        "name": "Pain Transference",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Trait",
-        "effect": "Whenever a character takes additional Heat dealt by <strong>Tear Down</strong> on the Witch’s next turn, all other hostile characters within <strong>Range 3</strong> of that character also take the same amount of <strong>heat</strong>.",
-        "tags": []
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the Witch chains their target’s systems to a space within <strong>Range 3</strong> of the target. If the target moves more than <strong>3 spaces</strong> from that point (voluntarily or otherwise), they take <strong>{2/3/4} Heat</strong> and become <strong>Jammed</strong> until the end of their next turn, but the effect ends. Otherwise, they are chained until the Witch is destroyed or <strong>Stunned</strong>, or until the end of the scene.",
+    "tags": [
+      {
+        "id": "tg_quick_tech"
+      }
+    ],
+    "tech_type": "Quick",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_petrify_witch",
+    "name": "Petrify",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": false
     },
-    {
-        "id": "npc-rebake_npcf_immolate_witch",
-        "name": "Immolate",
-        "origin": {
-            "type": "Class",
-            "name": "Witch [K]",
-            "base": false
-        },
-        "locked": false,
-        "type": "Tech",
-        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>burn</strong> equal to their current Heat. If the target is in the <strong>Danger Zone</strong>, all characters of the Witch's choice within a <strong>Burst 2</strong> area around the target must pass a <strong>Systems</strong> save or take half the amount of burn that the target takes. On a miss, the target takes <strong>2 Heat</strong> and becomes <strong>Impaired</strong> until the end of their next turn.",
-        "tags": [
-            {
-                "id": "tg_limited",
-                "val": 1
-            },
-            {
-                "id": "tg_full_tech"
-            }
-        ],
-        "tech_type": "Full",
-        "attack_bonus": [
-            2,
-            4,
-            6
-        ],
-        "accuracy": [
-            1,
-            1,
-            1
-        ]
-    }
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target becomes <strong>Slowed</strong> until the end of their next turn. When <strong>Slowed</strong> expires, they then become <strong>Immobilized</strong> until the end of their next turn. When <strong>Immobilized</strong> expires, they then become <strong>Stunned</strong> until the end of their next turn. Clearing any of these conditions (e.g. with <strong>Stabilize</strong>) prevents further conditions from occurring on subsequent turns.\n\nThis system can't be used again while it is currently in the process of affecting a character, and it can only be used 1/scene on each character.",
+    "tags": [
+      {
+        "id": "tg_full_tech"
+      }
+    ],
+    "tech_type": "Full",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ]
+  },
+  {
+    "id": "npc-rebake_npcf_pain_transference_witch",
+    "name": "Pain Transference",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Trait",
+    "effect": "Whenever a character takes additional Heat dealt by <strong>Tear Down</strong> on the Witch’s next turn, all other hostile characters within <strong>Range 3</strong> of that character also take the same amount of <strong>heat</strong>.",
+    "tags": []
+  },
+  {
+    "id": "npc-rebake_npcf_immolate_witch",
+    "name": "Immolate",
+    "origin": {
+      "type": "Class",
+      "name": "Witch [K]",
+      "base": false
+    },
+    "locked": false,
+    "type": "Tech",
+    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>burn</strong> equal to their current Heat. If the target is in the <strong>Danger Zone</strong>, all characters of the Witch's choice within a <strong>Burst 2</strong> area around the target must pass a <strong>Systems</strong> save or take half the amount of burn that the target takes. On a miss, the target takes <strong>2 Heat</strong> and becomes <strong>Impaired</strong> until the end of their next turn.",
+    "tags": [
+      {
+        "id": "tg_limited",
+        "val": 1
+      },
+      {
+        "id": "tg_full_tech"
+      }
+    ],
+    "tech_type": "Full",
+    "attack_bonus": [
+      2,
+      4,
+      6
+    ],
+    "accuracy": [
+      1,
+      1,
+      1
+    ]
+  }
 ]

--- a/NPC Rebakes/npc_features.json
+++ b/NPC Rebakes/npc_features.json
@@ -1,5052 +1,5060 @@
 [
-  {
-    "id": "npc-rebake_npcf_ssc_flight_system_ace",
-    "name": "SSC FLIGHT SYSTEM",
-    "origin": {
-      "type": "Class",
-      "name": "ACE",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_ssc_flight_system_ace",
+        "name": "SSC Flight System",
+        "origin": {
+            "type": "Class",
+            "name": "Ace [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Ace can count any or all of their movement as <strong>flying</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Ace can count any or all of their movement as <strong>flying</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_missile_launcher_ace",
-    "name": "MISSILE LAUNCHER",
-    "origin": {
-      "type": "Class",
-      "name": "ACE",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "Attacks made with this weapon against targets that have <strong>Lock On</strong> ignore cover.",
-    "tags": [
-      {
-        "id": "tg_smart"
-      }
-    ],
-    "weapon_type": "Main Launcher",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Explosive",
+    {
+        "id": "npc-rebake_npcf_missile_launcher_ace",
+        "name": "Missile Launcher",
+        "origin": {
+            "type": "Class",
+            "name": "Ace [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "Attacks made with this weapon against targets that have <strong>Lock On</strong> ignore cover.",
+        "tags": [
+            {
+                "id": "tg_smart"
+            }
+        ],
+        "weapon_type": "Main Launcher",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          4,
-          6,
-          8
+            {
+                "type": "Explosive",
+                "damage": [
+                    4,
+                    6,
+                    8
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 10
+            },
+            {
+                "type": "Blast",
+                "val": 1
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_barrel_roll_ace",
+        "name": "Barrel Roll",
+        "origin": {
+            "type": "Class",
+            "name": "Ace [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Ace performs a barrel roll, flying <strong>6 spaces</strong> in any direction and causing the attack to miss. This movement ignores engagement and does not provoke reactions. This reaction can't be used if the Ace can't move (e.g. if it's <strong>Slowed</strong> or <strong>Immobilized</strong>).",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "A melee or ranged attack hits the Ace."
+    },
+    {
+        "id": "npc-rebake_npcf_strafe_ace",
+        "name": "Strafe",
+        "origin": {
+            "type": "Class",
+            "name": "Ace [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "<strong>1/round</strong>, the Ace can fly spaces equal to their <strong>Speed</strong> in any direction, automatically dealing <strong>{3/4/5} kinetic damage</strong> to one character below or adjacent to the path taken, plus any number of additional characters below or adjacent to the path taken who have <strong>Lock On</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 10
-      },
-      {
-        "type": "Blast",
-        "val": 1
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_barrel_roll_ace",
-    "name": "BARREL ROLL",
-    "origin": {
-      "type": "Class",
-      "name": "ACE",
-      "base": true
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Ace performs a barrel roll, flying <strong>6 spaces</strong> in any direction and causing the attack to miss. This movement ignores engagement and does not provoke reactions. This reaction can't be used if the Ace can't move (e.g. if it's <strong>Slowed</strong> or <strong>Immobilized</strong>).",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "A melee or ranged attack hits the Ace."
-  },
-  {
-    "id": "npc-rebake_npcf_strafe_ace",
-    "name": "STRAFE",
-    "origin": {
-      "type": "Class",
-      "name": "ACE",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "<strong>1/round</strong>, the Ace can fly spaces equal to their <strong>Speed</strong> in any direction, automatically dealing <strong>{3/4/5} kinetic damage</strong> to one character below or adjacent to the path taken, plus any number of additional characters below or adjacent to the path taken who have <strong>Lock On</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_missile_swarm_ace",
-    "name": "MISSILE SWARM",
-    "origin": {
-      "type": "Class",
-      "name": "ACE",
-      "base": false
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "This weapon deals double damage to characters with <strong>Lock On</strong>, and doesn’t affect allied characters.",
-    "tags": [
-      {
-        "id": "tg_loading"
-      }
-    ],
-    "weapon_type": "Main Launcher",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Explosive",
+    {
+        "id": "npc-rebake_npcf_missile_swarm_ace",
+        "name": "Missile Swarm",
+        "origin": {
+            "type": "Class",
+            "name": "Ace [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "This weapon deals double damage to characters with <strong>Lock On</strong>, and doesn’t affect allied characters.",
+        "tags": [
+            {
+                "id": "tg_loading"
+            }
+        ],
+        "weapon_type": "Main Launcher",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          3,
-          4,
-          5
+            {
+                "type": "Explosive",
+                "damage": [
+                    3,
+                    4,
+                    5
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Burst",
+                "val": 5
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_full_throttle_ace",
+        "name": "Full Throttle",
+        "origin": {
+            "type": "Class",
+            "name": "Ace [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Ace moves <strong>10 spaces</strong> in any direction and gains <strong>soft cover</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_reaction"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 5
+            }
+        ],
+        "trigger": "An enemy character in line of sight moves."
+    },
+    {
+        "id": "npc-rebake_npcf_countermeasures_ace",
+        "name": "Countermeasures",
+        "origin": {
+            "type": "Class",
+            "name": "Ace [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "Whenever the Ace would gain a condition from a hostile character, it may spend a charge from this system to ignore that condition. The Ace then takes <strong>4 Heat</strong>, and the character that inflicted that condition gains <strong>Lock On</strong>.",
+        "tags": [
+            {
+                "id": "tg_limited",
+                "val": "1"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Burst",
-        "val": 5
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_full_throttle_ace",
-    "name": "FULL THROTTLE",
-    "origin": {
-      "type": "Class",
-      "name": "ACE",
-      "base": false
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Ace moves <strong>10 spaces</strong> in any direction and gains <strong>soft cover</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_reaction"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 5
-      }
-    ],
-    "trigger": "An enemy character in line of sight moves."
-  },
-  {
-    "id": "npc-rebake_npcf_countermeasures_ace",
-    "name": "COUNTERMEASURES",
-    "origin": {
-      "type": "Class",
-      "name": "ACE",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_emergency_jettison_ace",
+        "name": "Emergency Jettison",
+        "origin": {
+            "type": "Class",
+            "name": "Ace [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Whenever the Ace is destroyed, it instead moves up to its <strong>Speed</strong> and immediately lands, remaining at <strong>1 HP</strong>. The <strong>SSC Flight System</strong> is then permanently destroyed, and all of the Ace's other systems and traits are disabled. If the <strong>SSC Flight System</strong> is already destroyed, this trait has no effect.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "Whenever the Ace would gain a condition from a hostile character, it may spend a charge from this system to ignore that condition. The Ace then takes <strong>4 Heat</strong>, and the character that inflicted that condition gains <strong>Lock On</strong>.",
-    "tags": [
-      {
-        "id": "tg_limited",
-        "val": "1"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_emergency_jettison_ace",
-    "name": "EMERGENCY JETTISON",
-    "origin": {
-      "type": "Class",
-      "name": "ACE",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Whenever the Ace is destroyed, it instead moves up to its <strong>Speed</strong> and immediately lands, remaining at <strong>1 HP</strong>. The <strong>SSC Flight System</strong> is then permanently destroyed, and all of the Ace's other systems and traits are disabled. If the <strong>SSC Flight System</strong> is already destroyed, this trait has no effect.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_light_laser_aegis",
-    "name": "LIGHT LASER",
-    "origin": {
-      "type": "Class",
-      "name": "AEGIS",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [],
-    "weapon_type": "Main Cannon",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Energy",
+    {
+        "id": "npc-rebake_npcf_light_laser_aegis",
+        "name": "Light Laser",
+        "origin": {
+            "type": "Class",
+            "name": "Aegis [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [],
+        "weapon_type": "Main Cannon",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          3,
-          3,
-          3
+            {
+                "type": "Energy",
+                "damage": [
+                    3,
+                    3,
+                    3
+                ]
+            },
+            {
+                "type": "Burn",
+                "damage": [
+                    2,
+                    3,
+                    4
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 8
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_defense_net_aegis",
+        "name": "Defense Net",
+        "origin": {
+            "type": "Class",
+            "name": "Aegis [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Aegis spreads a powerful, shimmering repulsion shield over a <strong>Burst 2</strong> area. While active, the Aegis is <strong>Immobilized</strong>, but all ranged, melee, and tech attacks against characters or objects within the affected area that originate outside the area receive <strong>+2 Difficulty</strong> and cannot result in <strong>critical hits</strong>; whenever an attack receiving this <strong>Difficulty</strong> misses, the Aegis takes <strong>2 Heat</strong>. Characters within the affected area may attack characters within and outside of the area normally.<br>Allied characters within the affected area also gain <strong>Immunity</strong> to <strong>Impaired</strong> and <strong>Slowed</strong>, and remove these conditions when they enter the area if they already have them.<br>This effect lasts until the Aegis ends it as a <strong>protocol</strong> or is destroyed. If the Aegis exceeds their <strong>Heat Cap</strong>, becomes <strong>Stunned</strong>, or becomes <strong>Jammed</strong> while the shield is active, the shield deactivates and can't be reactivated until the end of the Aegis' next turn.",
+        "tags": [
+            {
+                "id": "tg_shield"
+            },
+            {
+                "id": "tg_full_action"
+            }
         ]
-      },
-      {
-        "type": "Burn",
+    },
+    {
+        "id": "npc-rebake_npcf_regenerative_shielding_aegis",
+        "name": "Regenerative Shielding",
+        "origin": {
+            "type": "Class",
+            "name": "Aegis [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Aegis has <strong>Immunity</strong> to <strong>Impaired</strong> and <strong>Slowed</strong> and can’t be critically hit.",
+        "immunity": [
+            "Impaired",
+            "Slowed",
+            "Critical Hits"
+        ],
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_focused_shielding_aegis",
+        "name": "Focused Shielding",
+        "origin": {
+            "type": "Class",
+            "name": "Aegis [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "That character gains <strong>resistance to all damage from the attack</strong>, then the <strong>Defense Net</strong> is deactivated.",
+        "tags": [
+            {
+                "id": "tg_reaction"
+            },
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ],
+        "trigger": "An allied character within your <strong>Defense Net</strong> area is hit by a ranged or melee attack."
+    },
+    {
+        "id": "npc-rebake_npcf_guardian_aegis",
+        "name": "Guardian",
+        "origin": {
+            "type": "Class",
+            "name": "Aegis [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Allied characters can use the Aegis for <strong>hard cover</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_ring_of_fire_aegis",
+        "name": "Ring of Fire",
+        "origin": {
+            "type": "Class",
+            "name": "Aegis [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Any hostile characters that start their turn inside the area affected by the <strong>Defense Net</strong> or that enter it for the first time in a round take <strong>2 Heat</strong> and become <strong>Shredded</strong> until they leave the area.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_remote_projector_aegis",
+        "name": "Remote Projector",
+        "origin": {
+            "type": "Class",
+            "name": "Aegis [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When the Aegis activates <strong>Defense Net</strong>, it may choose a free space within <strong>Range 10</strong> and generate a <strong>Burst 2</strong> area centered on that space instead. All other effects of <strong>Defense Net</strong> remain the same while this remote field is active (e.g. the Aegis is <strong>Immobilized</strong>, etc).",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_ha_blackwall_system_aegis",
+        "name": "HA Blackwall System",
+        "origin": {
+            "type": "Class",
+            "name": "Aegis [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "As a full action, the Aegis generates a pitch-black wall of blinkspace <strong>5 spaces high</strong> covering a <strong>line 10</strong> area starting within <strong>range 5</strong>. All spaces must be free. The wall blocks line of sight, effects or attacks and provides <strong>hard cover</strong>. Characters that start their turn in the wall or who enter it on their turn roll <strong>1d6</strong>. On a <strong>4+</strong> they are removed from play until the end of their next turn, when they reappear in a free space of their choice in <strong>Range 10</strong> of the wall. If there are no free spaces, they return when a space becomes free. The wall lasts until the Aegis ends it as a <strong>quick action</strong>, or is destroyed. When it ends, characters remaining in blinkspace reappear.",
+        "tags": [
+            {
+                "id": "tg_limited",
+                "val": 1
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_light_machine_gun_archer",
+        "name": "Light Machine Gun",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_reliable",
+                "val": "{3/4/5}"
+            }
+        ],
+        "weapon_type": "Main Cannon",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          2,
-          3,
-          4
+            {
+                "type": "kinetic",
+                "damage": [
+                    5,
+                    6,
+                    7
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 10
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_suppress_archer",
+        "name": "Suppress",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Archer chooses a target within line of sight and <strong>Range 10</strong>: they become <strong>Impaired</strong> and the Archer gains the <strong>Moving Target</strong> reaction.<br>This effect lasts until the Archer uses <strong>Moving Target</strong>; the target damages the Archer or leaves the Archer’s line of sight; the Archer is <strong>Stunned</strong>, <strong>Jammed</strong>, or destroyed; the Archer chooses a new target for this action; or, the Archer ends it as a free action.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": ""
+    },
+    {
+        "id": "npc-rebake_npcf_moving_target_archer",
+        "name": "Moving Target",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Archer makes an attack against them with the <strong>Light Machine Gun</strong>. This attack interrupts and resolves before the triggering movement",
+        "tags": [
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "The Archer’s <strong>Suppress</strong> target starts to move."
+    },
+    {
+        "id": "npc-rebake_npcf_superior_sentinel_archer",
+        "name": "Superior Sentinel",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Archer gains <strong>+1 Accuracy</strong> on all attacks made as reactions (e.g., <strong>Overwatch</strong>).",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_covering_fire_archer",
+        "name": "Covering Fire",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Archer creates a <strong>Blast 3</strong> area within <strong>Range 10</strong> and line of sight, and gains the <strong>Got Your Back</strong> reaction. This area lasts until the end of the Archer's next turn or until the Archer creates a new area, and this Reaction can be taken as many times per round as it is triggered.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 4
+            },
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_reaction"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 8
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_defense_net_aegis",
-    "name": "DEFENSE NET",
-    "origin": {
-      "type": "Class",
-      "name": "AEGIS",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Aegis spreads a powerful, shimmering repulsion shield over a <strong>Burst 2</strong> area. While active, the Aegis is <strong>Immobilized</strong>, but all ranged, melee, and tech attacks against characters or objects within the affected area that originate outside the area receive <strong>+2 Difficulty</strong> and cannot result in <strong>critical hits</strong>; whenever an attack receiving this <strong>Difficulty</strong> misses, the Aegis takes <strong>2 Heat</strong>. Characters within the affected area may attack characters within and outside of the area normally.<br>Allied characters within the affected area also gain <strong>Immunity</strong> to <strong>Impaired</strong> and <strong>Slowed</strong>, and remove these conditions when they enter the area if they already have them.<br>This effect lasts until the Aegis ends it as a <strong>protocol</strong> or is destroyed. If the Aegis exceeds their <strong>Heat Cap</strong>, becomes <strong>Stunned</strong>, or becomes <strong>Jammed</strong> while the shield is active, the shield deactivates and can't be reactivated until the end of the Aegis' next turn.",
-    "tags": [
-      {
-        "id": "tg_shield"
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_regenerative_shielding_aegis",
-    "name": "REGENERATIVE SHIELDING",
-    "origin": {
-      "type": "Class",
-      "name": "AEGIS",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_got_your_back_archer",
+        "name": "Got Your Back",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Archer may attack that character with the <strong>Light Machine Gun</strong>.",
+        "tags": [
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "A character in the <strong>Covering Fire</strong> area makes an attack."
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Aegis has <strong>Immunity</strong> to <strong>Impaired</strong> and <strong>Slowed</strong> and can’t be critically hit.",
-    "immunity": [
-      "Impaired",
-      "Slowed",
-      "Critical Hits"
-    ],
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_focused_shielding_aegis",
-    "name": "FOCUSED SHIELDING",
-    "origin": {
-      "type": "Class",
-      "name": "AEGIS",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_impending_threat_archer",
+        "name": "Impending Threat",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "<strong>Moving Target</strong>'s trigger now includes the target taking any action that does not target the Archer",
+        "tags": []
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "That character gains <strong>resistance to all damage from the attack</strong>, then the <strong>Defense Net</strong> is deactivated.",
-    "tags": [
-      {
-        "id": "tg_reaction"
-      },
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ],
-    "trigger": "An allied character within your <strong>Defense Net</strong> area is hit by a ranged or melee attack."
-  },
-  {
-    "id": "npc-rebake_npcf_guardian_aegis",
-    "name": "GUARDIAN",
-    "origin": {
-      "type": "Class",
-      "name": "AEGIS",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_flush_out_archer",
+        "name": "Flush Out",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Archer chooses a character within <strong>Range 10</strong>: that character must either move their <strong>Speed</strong> in a direction of the Archer's choice, or allow the Archer to attack them with the <strong>Light Machine Gun</strong>. This movement ignores engagement and does not provoke reactions.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 4
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Allied characters can use the Aegis for <strong>hard cover</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_ring_of_fire_aegis",
-    "name": "RING OF FIRE",
-    "origin": {
-      "type": "Class",
-      "name": "AEGIS",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_blinding_shells_archer",
+        "name": "Blinding Shells",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "After the Archer makes a successful attack, they may force their target to pass an <strong>Engineering</strong> save. On a failure, the target only has line of sight to adjacent spaces until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Any hostile characters that start their turn inside the area affected by the <strong>Defense Net</strong> or that enter it for the first time in a round take <strong>2 Heat</strong> and become <strong>Shredded</strong> until they leave the area.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_remote_projector_aegis",
-    "name": "REMOTE PROJECTOR",
-    "origin": {
-      "type": "Class",
-      "name": "AEGIS",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_fire_and_maneuver_archer",
+        "name": "Fire and Maneuver",
+        "origin": {
+            "type": "Class",
+            "name": "Archer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Archer may <strong>Boost</strong>. If they end this movement within <strong>Range 10</strong> and line of sight of the triggering character, that character takes <strong>{3/4/5} kinetic damage</strong>.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "An enemy character in line of sight moves."
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When the Aegis activates <strong>Defense Net</strong>, it may choose a free space within <strong>Range 10</strong> and generate a <strong>Burst 2</strong> area centered on that space instead. All other effects of <strong>Defense Net</strong> remain the same while this remote field is active (e.g. the Aegis is <strong>Immobilized</strong>, etc).",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_ha_blackwall_system_aegis",
-    "name": "HA BLACKWALL SYSTEM",
-    "origin": {
-      "type": "Class",
-      "name": "AEGIS",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_kai_bioplating_assassin",
+        "name": "Kai Bioplating",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Assassin gains <strong>+1 Accuracy</strong> on all <strong>Agility</strong> checks; additionally, they climb and swim at normal speed, ignore <strong>difficult terrain</strong>, and, when making a standard move, can jump horizontally up to their <strong>Speed</strong> and vertically up to half their <strong>Speed</strong> (in any combination).",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "As a full action, the Aegis generates a pitch-black wall of blinkspace <strong>5 spaces high</strong> covering a <strong>line 10</strong> area starting within <strong>range 5</strong>. All spaces must be free. The wall blocks line of sight, effects or attacks and provides <strong>hard cover</strong>. Characters that start their turn in the wall or who enter it on their turn roll <strong>1d6</strong>. On a <strong>4+</strong> they are removed from play until the end of their next turn, when they reappear in a free space of their choice in <strong>Range 10</strong> of the wall. If there are no free spaces, they return when a space becomes free. The wall lasts until the Aegis ends it as a <strong>quick action</strong>, or is destroyed. When it ends, characters remaining in blinkspace reappear.",
-    "tags": [
-      {
-        "id": "tg_limited",
-        "val": 1
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_light_machine_gun_archer",
-    "name": "LIGHT MACHINE GUN",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_reliable",
-        "val": "{3/4/5}"
-      }
-    ],
-    "weapon_type": "Main Cannon",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_heated_blade_assassin",
+        "name": "Heated Blade",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "Deals double damage to <strong>Prone</strong>, <strong>Shredded</strong>, <strong>Immobilized</strong>, or <strong>Stunned</strong> targets.",
+        "tags": [],
+        "weapon_type": "Main Melee",
+        "attack_bonus": [
+            2,
+            3,
+            4
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ],
         "damage": [
-          5,
-          6,
-          7
+            {
+                "type": "Kinetic",
+                "damage": [
+                    4,
+                    5,
+                    6
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 2
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_assassins_mark_assassin",
+        "name": "Assassin’s Mark",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Assassin chooses a character in line of sight. For the rest of the scene, these effects apply:<ul><li>It has Resistance to that target’s damage.</li><li>Damage it deals to that target cannot be reduced.</li><li>It gains <strong>+1 Accuracy</strong> on all saves forced by that target.</li></ul><br>The Assassin can only choose a new target if the current target is destroyed.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 10
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_suppress_archer",
-    "name": "SUPPRESS",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": true
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Archer chooses a target within line of sight and <strong>Range 10</strong>: they become <strong>Impaired</strong> and the Archer gains the <strong>Moving Target</strong> reaction.<br>This effect lasts until the Archer uses <strong>Moving Target</strong>; the target damages the Archer or leaves the Archer’s line of sight; the Archer is <strong>Stunned</strong>, <strong>Jammed</strong>, or destroyed; the Archer chooses a new target for this action; or, the Archer ends it as a free action.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": ""
-  },
-  {
-    "id": "npc-rebake_npcf_moving_target_archer",
-    "name": "MOVING TARGET",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_leap_assassin",
+        "name": "Leap",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Assassin flies <strong>6 spaces</strong> in any direction but must land on a surface. When they land, characters adjacent to the Assassin must succeed on an <strong>Agility</strong> save or be knocked <strong>Prone</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 5
+            }
+        ]
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Archer makes an attack against them with the <strong>Light Machine Gun</strong>. This attack interrupts and resolves before the triggering movement",
-    "tags": [
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "The Archer’s <strong>Suppress</strong> target starts to move."
-  },
-  {
-    "id": "npc-rebake_npcf_superior_sentinel_archer",
-    "name": "SUPERIOR SENTINEL",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Archer gains <strong>+1 Accuracy</strong> on all attacks made as reactions (e.g., <strong>Overwatch</strong>).",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_covering_fire_archer",
-    "name": "COVERING FIRE",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Archer creates a <strong>Blast 3</strong> area within <strong>Range 10</strong> and line of sight, and gains the <strong>Got Your Back</strong> reaction. This area lasts until the end of the Archer's next turn or until the Archer creates a new area, and this Reaction can be taken as many times per round as it is triggered.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 4
-      },
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_got_your_back_archer",
-    "name": "GOT YOUR BACK",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Archer may attack that character with the <strong>Light Machine Gun</strong>.",
-    "tags": [
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "A character in the <strong>Covering Fire</strong> area makes an attack."
-  },
-  {
-    "id": "npc-rebake_npcf_impending_threat_archer",
-    "name": "IMPENDING THREAT",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "<strong>Moving Target</strong>'s trigger now includes the target taking any action that does not target the Archer",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_flush_out_archer",
-    "name": "FLUSH OUT",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Archer chooses a character within <strong>Range 10</strong>: that character must either move their <strong>Speed</strong> in a direction of the Archer's choice, or allow the Archer to attack them with the <strong>Light Machine Gun</strong>. This movement ignores engagement and does not provoke reactions.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 4
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_blinding_shells_archer",
-    "name": "BLINDING SHELLS",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "After the Archer makes a successful attack, they may force their target to pass an <strong>Engineering</strong> save. On a failure, the target only has line of sight to adjacent spaces until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_fire_and_maneuver_archer",
-    "name": "FIRE AND MANEUVER",
-    "origin": {
-      "type": "Class",
-      "name": "ARCHER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Archer may <strong>Boost</strong>. If they end this movement within <strong>Range 10</strong> and line of sight of the triggering character, that character takes <strong>{3/4/5} kinetic damage</strong>.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "An enemy character in line of sight moves."
-  },
-  {
-    "id": "npc-rebake_npcf_kai_bioplating_assassin",
-    "name": "KAI BIOPLATING",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": true
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Assassin gains <strong>+1 Accuracy</strong> on all <strong>Agility</strong> checks; additionally, they climb and swim at normal speed, ignore <strong>difficult terrain</strong>, and, when making a standard move, can jump horizontally up to their <strong>Speed</strong> and vertically up to half their <strong>Speed</strong> (in any combination).",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_heated_blade_assassin",
-    "name": "HEATED BLADE",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "Deals double damage to <strong>Prone</strong>, <strong>Shredded</strong>, <strong>Immobilized</strong>, or <strong>Stunned</strong> targets.",
-    "tags": [],
-    "weapon_type": "Main Melee",
-    "attack_bonus": [
-      2,
-      3,
-      4
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ],
-    "damage": [
-      {
-        "type": "Kinetic",
+    {
+        "id": "npc-rebake_npcf_devils_cough_shotgun_assassin",
+        "name": "“Devil’s Cough” Shotgun",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_knockback",
+                "val": 2
+            },
+            {
+                "id": "tg_loading"
+            }
+        ],
+        "weapon_type": "Heavy CQB",
+        "attack_bonus": [
+            0,
+            1,
+            2
+        ],
         "damage": [
-          4,
-          5,
-          6
+            {
+                "type": "kinetic",
+                "damage": [
+                    10,
+                    15,
+                    20
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 3
+            },
+            {
+                "type": "Threat",
+                "val": 3
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_spinning_kick_assassin",
+        "name": "Spinning Kick",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Assassin chooses a character next to them: they must pass a <strong>Hull</strong> save or be pushed <strong>4 spaces</strong> away from the Assassin and knocked <strong>Prone</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 2
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_assassins_mark_assassin",
-    "name": "ASSASSIN’S MARK",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": true
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Assassin chooses a character in line of sight. For the rest of the scene, these effects apply:<ul><li>It has Resistance to that target’s damage.</li><li>Damage it deals to that target cannot be reduced.</li><li>It gains <strong>+1 Accuracy</strong> on all saves forced by that target.</li></ul><br>The Assassin can only choose a new target if the current target is destroyed.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_leap_assassin",
-    "name": "LEAP",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_shroud_projector_assassin",
+        "name": "Shroud Projector",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Assassin sets off a charge, creating a <strong>Burst 3</strong> concealing shroud. The Assassin gains <strong>soft cover</strong> within the affected area, and characters other than the Assassin fully inside or outside the area cannot draw line of sight into or out of the area. Characters partially within the area are not affected. The <strong>Heated Blade</strong> deals double damage to characters inside this area (as though they were <strong>Prone</strong> etc). This effect lasts until the end of the Assassin’s next turn, or until the Assassin uses this system again.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Assassin flies <strong>6 spaces</strong> in any direction but must land on a surface. When they land, characters adjacent to the Assassin must succeed on an <strong>Agility</strong> save or be knocked <strong>Prone</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 5
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_devils_cough_shotgun_assassin",
-    "name": "“DEVIL’S COUGH” SHOTGUN",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_explosive_knives_assassin",
+        "name": "Explosive Knives",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Assassin throws an explosive knife at a character within <strong>Range 5</strong>, making a ranged attack at <strong>{+2/+4/+6}</strong>. On a hit, the knife embeds itself in the target and explodes at the end of their next turn, dealing <strong>{4/6/8} explosive damage</strong> in a <strong>Burst 1</strong> area and forcing the struck target to pass a <strong>Hull</strong> save or become <strong>Shredded</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_knockback",
-        "val": 2
-      },
-      {
-        "id": "tg_loading"
-      }
-    ],
-    "weapon_type": "Heavy CQB",
-    "attack_bonus": [
-      0,
-      1,
-      2
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_transfix_assassin",
+        "name": "Transfix",
+        "origin": {
+            "type": "Class",
+            "name": "Assassin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Assassin jams their blade into a vital part of an adjacent character: that character must pass an <strong>Engineering</strong> save or become <strong>Stunned</strong>. While <strong>Stunned</strong> this way, the Assassin becomes <strong>Immobilized</strong>.This effect lasts until the Assassin and the target are no longer adjacent or until the target takes <strong>structure damage</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_quick_tech"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_weapon_heavy_assault",
+        "name": "Heavy Assault Rifle",
+        "origin": {
+            "type": "Class",
+            "name": "Assault [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "This weapon gains <strong>+1 Accuracy</strong> against targets that do not have <strong>cover.</strong>",
+        "tags": [],
+        "weapon_type": "Heavy Rifle",
+        "attack_bonus": [
+            0,
+            1,
+            2
+        ],
         "damage": [
-          10,
-          15,
-          20
+            {
+                "type": "Kinetic",
+                "damage": [
+                    6,
+                    8,
+                    10
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 10
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 3
-      },
-      {
-        "type": "Threat",
-        "val": 3
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_spinning_kick_assassin",
-    "name": "SPINNING KICK",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": false
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Assassin chooses a character next to them: they must pass a <strong>Hull</strong> save or be pushed <strong>4 spaces</strong> away from the Assassin and knocked <strong>Prone</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_shroud_projector_assassin",
-    "name": "SHROUD PROJECTOR",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Assassin sets off a charge, creating a <strong>Burst 3</strong> concealing shroud. The Assassin gains <strong>soft cover</strong> within the affected area, and characters other than the Assassin fully inside or outside the area cannot draw line of sight into or out of the area. Characters partially within the area are not affected. The <strong>Heated Blade</strong> deals double damage to characters inside this area (as though they were <strong>Prone</strong> etc). This effect lasts until the end of the Assassin’s next turn, or until the Assassin uses this system again.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_explosive_knives_assassin",
-    "name": "EXPLOSIVE KNIVES",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Assassin throws an explosive knife at a character within <strong>Range 5</strong>, making a ranged attack at <strong>{+2/+4/+6}</strong>. On a hit, the knife embeds itself in the target and explodes at the end of their next turn, dealing <strong>{4/6/8} explosive damage</strong> in a <strong>Burst 1</strong> area and forcing the struck target to pass a <strong>Hull</strong> save or become <strong>Shredded</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_transfix_assassin",
-    "name": "TRANSFIX",
-    "origin": {
-      "type": "Class",
-      "name": "ASSASSIN",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Assassin jams their blade into a vital part of an adjacent character: that character must pass an <strong>Engineering</strong> save or become <strong>Stunned</strong>. While <strong>Stunned</strong> this way, the Assassin becomes <strong>Immobilized</strong>.This effect lasts until the Assassin and the target are no longer adjacent or until the target takes <strong>structure damage</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_quick_tech"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_weapon_heavy_assault",
-    "name": "HEAVY ASSAULT RIFLE",
-    "origin": {
-      "type": "Class",
-      "name": "ASSAULT",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "This weapon gains <strong>+1 Accuracy</strong> against targets that do not have <strong>cover.</strong>",
-    "tags": [],
-    "weapon_type": "Heavy Rifle",
-    "attack_bonus": [
-      0,
-      1,
-      2
-    ],
-    "damage": [
-      {
-        "type": "Kinetic",
+    {
+        "id": "npc-rebake_npcf_weapon_combat_knife",
+        "name": "Combat Knife",
+        "origin": {
+            "type": "Class",
+            "name": "Assault [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "tags": [],
+        "weapon_type": "Auxiliary Melee",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          6,
-          8,
-          10
+            {
+                "type": "Kinetic",
+                "damage": [
+                    4,
+                    5,
+                    6
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 1
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 10
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_weapon_combat_knife",
-    "name": "COMBAT KNIFE",
-    "origin": {
-      "type": "Class",
-      "name": "ASSAULT",
-      "base": true
     },
-    "locked": false,
-    "type": "Weapon",
-    "tags": [],
-    "weapon_type": "Auxiliary Melee",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Kinetic",
+    {
+        "id": "npc-rebake_npcf_trait_hunker_down",
+        "name": "Hunker Down",
+        "origin": {
+            "type": "Class",
+            "name": "Assault [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Assault gains <strong>Resistance to all damage from the attack</strong>, but becomes <strong>Slowed</strong> until the end of its next turn.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ],
+        "trigger": "An attack hits the Assault, but damage hasn't been rolled yet."
+    },
+    {
+        "id": "npc-rebake_npcf_trait_rank_discipline",
+        "name": "Rank Discipline",
+        "origin": {
+            "type": "Class",
+            "name": "Assault [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Assault gains <strong>+1 Accuracy</strong> on all attacks, checks, and saves while adjacent to at least one allied character with the <strong>Mech</strong> tag.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_weapon_underslung_grenade",
+        "name": "Underslung Grenade Launcer",
+        "origin": {
+            "type": "Class",
+            "name": "Assault [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_knockback",
+                "val": 2
+            },
+            {
+                "id": "tg_loading"
+            }
+        ],
+        "weapon_type": "Auxiliary Launcher",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          4,
-          5,
-          6
+            {
+                "type": "Explosive",
+                "damage": [
+                    4,
+                    6,
+                    8
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 10
+            },
+            {
+                "type": "Blast",
+                "val": 1
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 1
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_trait_hunker_down",
-    "name": "HUNKER DOWN",
-    "origin": {
-      "type": "Class",
-      "name": "ASSAULT",
-      "base": true
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Assault gains <strong>Resistance to all damage from the attack</strong>, but becomes <strong>Slowed</strong> until the end of its next turn.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ],
-    "trigger": "An attack hits the Assault, but damage hasn't been rolled yet."
-  },
-  {
-    "id": "npc-rebake_npcf_trait_rank_discipline",
-    "name": "RANK DISCIPLINE",
-    "origin": {
-      "type": "Class",
-      "name": "ASSAULT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_system_micromissile_barrage",
+        "name": "Micro-Missile Barrage",
+        "origin": {
+            "type": "Class",
+            "name": "Assault [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Assault launches a <strong>Line 10</strong> volley of micro-missiles. All characters within the affected area must succeed on a <strong>Hull</strong> save or take {6/8/10} explosive damage. On a successful save, they take half damage.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Assault gains <strong>+1 Accuracy</strong> on all attacks, checks, and saves while adjacent to at least one allied character with the <strong>Mech</strong> tag.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_weapon_underslung_grenade",
-    "name": "UNDERSLUNG GRENADE LAUNCER",
-    "origin": {
-      "type": "Class",
-      "name": "ASSAULT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_trait_flank_and_fix",
+        "name": "Fix and Flank",
+        "origin": {
+            "type": "Class",
+            "name": "Assault [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Assault may target them with <strong>Overwatch</strong> using the <strong>Heavy Assault Rifle</strong>, dealing half damage on hit.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ],
+        "trigger": "A character who doesn't have cover from the Assault is successfully attacked by an allied character."
     },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_knockback",
-        "val": 2
-      },
-      {
-        "id": "tg_loading"
-      }
-    ],
-    "weapon_type": "Auxiliary Launcher",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Explosive",
+    {
+        "id": "npc-rebake_npcf_trait_stormtrooper",
+        "name": "Stormtrooper",
+        "origin": {
+            "type": "Class",
+            "name": "Assault [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "<strong>Hunker Down</strong> no longer causes the Assault to become <strong>Slowed</strong>. Whenever the Assault uses <strong>Hunker Down</strong>, they may also move up to their <strong>Speed</strong> as part of the Reaction.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_graviton_lance_barricade",
+        "name": "Graviton Lance",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "tags": [],
+        "weapon_type": "Main Cannon",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ],
         "damage": [
-          4,
-          6,
-          8
+            {
+                "type": "Energy",
+                "damage": [
+                    2,
+                    3,
+                    4
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 10
+            }
+        ],
+        "on_hit": "Target is <strong>Slowed</strong> until the end of their next turn."
+    },
+    {
+        "id": "npc-rebake_npcf_mobile_printer_barricade",
+        "name": "Mobile Printer",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Barricade prints a <strong>Size 2</strong> cube in a free area within <strong>Range 3</strong>. The cube provides <strong>hard cover</strong> and is a single object with <strong>20 HP</strong> and <strong>Evasion 5</strong>. The Barricade can only have one cube deployed at a time; if a new one is deployed, the first one dissolves.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 10
-      },
-      {
-        "type": "Blast",
-        "val": 1
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_system_micromissile_barrage",
-    "name": "MICRO-MISSILE BARRAGE",
-    "origin": {
-      "type": "Class",
-      "name": "ASSAULT",
-      "base": false
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Assault launches a <strong>Line 10</strong> volley of micro-missiles. All characters within the affected area must succeed on a <strong>Hull</strong> save or take {6/8/10} explosive damage. On a successful save, they take half damage.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_trait_flank_and_fix",
-    "name": "FLANK AND FIX",
-    "origin": {
-      "type": "Class",
-      "name": "ASSAULT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_drag_down_barricade",
+        "name": "Drag Down",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Barricade makes a tech attack against a character within <strong>Sensors</strong>. On a success, they take <strong>2 AP Energy damage</strong> per space that they voluntarily move until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ]
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Assault may target them with <strong>Overwatch</strong> using the <strong>Heavy Assault Rifle</strong>, dealing half damage on hit.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ],
-    "trigger": "A character who doesn't have cover from the Assault is successfully attacked by an allied character."
-  },
-  {
-    "id": "npc-rebake_npcf_trait_stormtrooper",
-    "name": "STORMTROOPER",
-    "origin": {
-      "type": "Class",
-      "name": "ASSAULT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_bulwark_mods_barricade",
+        "name": "Bulwark Mods",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Barricade ignores <strong>difficult terrain</strong> and <strong>dangerous terrain</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "<strong>Hunker Down</strong> no longer causes the Assault to become <strong>Slowed</strong>. Whenever the Assault uses <strong>Hunker Down</strong>, they may also move up to their <strong>Speed</strong> as part of the Reaction.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_graviton_lance_barricade",
-    "name": "GRAVITON LANCE",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_spike_barrier_barricade",
+        "name": "Spike Barrier",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The cube printed by Mobile Printer is covered in piercing spikes; the first time in a round any character moves adjacent to it, that character takes <strong>{2/3/4} AP kinetic damage</strong> and must pass an <strong>Agility</strong> save or lose all their remaining movement as though they had become <strong>Engaged</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Weapon",
-    "tags": [],
-    "weapon_type": "Main Cannon",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ],
-    "damage": [
-      {
-        "type": "Energy",
+    {
+        "id": "npc-rebake_npcf_extrudite_barricade",
+        "name": "Extrudite",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Barricade can print two separate cubes at a time with instead of one, and cubes no longer dissolve when new ones are printed. Replace <strong>Mobile Printer</strong> with <strong>Extruding Printer</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_extruding_printer_barricade",
+        "name": "Extruding Printer",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Barricade prints 2 <strong>Size 2</strong> cubes in free areas within <strong>Range 3</strong>. The cubes provides <strong>hard cover</strong> and are each single objects with <strong>20 HP</strong> and <strong>Evasion 5</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_seismic_repulsor_barricade",
+        "name": "Seismic Repulsor",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Barricade emits a seismic pulse from one of its printed cubes, creating a <strong>Burst 3</strong> area around it. All non-flying characters within that area must pass a <strong>Hull</strong> save or be knocked <strong>3 spaces</strong> back from the cube and knocked <strong>Prone</strong>. Allied characters affected this way (including the Barricade itself) are not knocked <strong>Prone</strong>. The cube is then destroyed.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_hunger_pursuit_limpets_barricade",
+        "name": "Hunger/Pursuit Limpets",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Barricade rapidly prints and deploys a field of tiny, mobile mines in a free <strong>Size 4</strong> area adjacent to them. The affected area becomes <strong>difficult terrain</strong>; additionally, hostile characters that enter the area forthe first time in a round or start their turn there must pass a <strong>Systems</strong> save or be <strong>Slowed</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_titan_snare_drone_barricade",
+        "name": "Titan-Snare Drone",
+        "origin": {
+            "type": "Class",
+            "name": "Barricade [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "Snare Drone (<strong>Size 1/2,</strong> <strong>HP {5/8/10}</strong>, <strong>Evasion {10/12/14}</strong>, <strong>E-Defense {10/12/14}</strong>, Tags: Drone)<br>This drone can be printed and deployed to any free adjacent space. When hostile characters move into or start their turn within <strong>Range 3</strong> of the drone, it emits a pulse, and they become <strong>Immobilized</strong> until the drone is destroyed.",
+        "tags": [
+            {
+                "id": "tg_drone"
+            },
+            {
+                "id": "tg_limited",
+                "val": 1
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_rotary_grenade_launcher_bastion",
+        "name": "Rotary Grenade Launcher",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "An adjacent allied character can spend a <strong>quick action</strong> to reload this weapon.",
+        "tags": [
+            {
+                "id": "tg_arcing"
+            },
+            {
+                "id": "tg_loading"
+            }
+        ],
+        "weapon_type": "Main Launcher",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          2,
-          3,
-          4
-        ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 10
-      }
-    ],
-    "on_hit": "Target is <strong>Slowed</strong> until the end of their next turn."
-  },
-  {
-    "id": "npc-rebake_npcf_mobile_printer_barricade",
-    "name": "MOBILE PRINTER",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": true
+            {
+                "type": "Explosive",
+                "damage": [
+                    4,
+                    6,
+                    8
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 8
+            },
+            {
+                "type": "Blast",
+                "val": 1
+            }
+        ],
+        "on_hit": ""
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Barricade prints a <strong>Size 2</strong> cube in a free area within <strong>Range 3</strong>. The cube provides <strong>hard cover</strong> and is a single object with <strong>20 HP</strong> and <strong>Evasion 5</strong>. The Barricade can only have one cube deployed at a time; if a new one is deployed, the first one dissolves.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_drag_down_barricade",
-    "name": "DRAG DOWN",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": true
-    },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Barricade makes a tech attack against a character within <strong>Sensors</strong>. On a success, they take <strong>2 AP Energy damage</strong> per space that they voluntarily move until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_bulwark_mods_barricade",
-    "name": "BULWARK MODS",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": true
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Barricade ignores <strong>difficult terrain</strong> and <strong>dangerous terrain</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_spike_barrier_barricade",
-    "name": "SPIKE BARRIER",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The cube printed by Mobile Printer is covered in piercing spikes; the first time in a round any character moves adjacent to it, that character takes <strong>{2/3/4} AP kinetic damage</strong> and must pass an <strong>Agility</strong> save or lose all their remaining movement as though they had become <strong>Engaged</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_extrudite_barricade",
-    "name": "EXTRUDITE",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Barricade can print two separate cubes at a time with instead of one, and cubes no longer dissolve when new ones are printed. Replace <strong>Mobile Printer</strong> with <strong>Extruding Printer</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_extruding_printer_barricade",
-    "name": "EXTRUDING PRINTER",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Barricade prints 2 <strong>Size 2</strong> cubes in free areas within <strong>Range 3</strong>. The cubes provides <strong>hard cover</strong> and are each single objects with <strong>20 HP</strong> and <strong>Evasion 5</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_seismic_repulsor_barricade",
-    "name": "SEISMIC REPULSOR",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Barricade emits a seismic pulse from one of its printed cubes, creating a <strong>Burst 3</strong> area around it. All non-flying characters within that area must pass a <strong>Hull</strong> save or be knocked <strong>3 spaces</strong> back from the cube and knocked <strong>Prone</strong>. Allied characters affected this way (including the Barricade itself) are not knocked <strong>Prone</strong>. The cube is then destroyed.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_hunger_pursuit_limpets_barricade",
-    "name": "HUNGER/PURSUIT LIMPETS",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Barricade rapidly prints and deploys a field of tiny, mobile mines in a free <strong>Size 4</strong> area adjacent to them. The affected area becomes <strong>difficult terrain</strong>; additionally, hostile characters that enter the area forthe first time in a round or start their turn there must pass a <strong>Systems</strong> save or be <strong>Slowed</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_titan_snare_drone_barricade",
-    "name": "TITAN-SNARE DRONE",
-    "origin": {
-      "type": "Class",
-      "name": "BARRICADE",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "Snare Drone (<strong>Size 1/2,</strong> <strong>HP {5/8/10}</strong>, <strong>Evasion {10/12/14}</strong>, <strong>E-Defense {10/12/14}</strong>, Tags: Drone)<br>This drone can be printed and deployed to any free adjacent space. When hostile characters move into or start their turn within <strong>Range 3</strong> of the drone, it emits a pulse, and they become <strong>Immobilized</strong> until the drone is destroyed.",
-    "tags": [
-      {
-        "id": "tg_drone"
-      },
-      {
-        "id": "tg_limited",
-        "val": 1
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_rotary_grenade_launcher_bastion",
-    "name": "ROTARY GRENADE LAUNCHER",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "An adjacent allied character can spend a <strong>quick action</strong> to reload this weapon.",
-    "tags": [
-      {
-        "id": "tg_arcing"
-      },
-      {
-        "id": "tg_loading"
-      }
-    ],
-    "weapon_type": "Main Launcher",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Explosive",
+    {
+        "id": "npc-rebake_npcf_heavy_assault_shield_bastion",
+        "name": "Heavy Assault Shield",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_knockback",
+                "val": 1
+            }
+        ],
+        "weapon_type": "Heavy Melee",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          4,
-          6,
-          8
-        ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 8
-      },
-      {
-        "type": "Blast",
-        "val": 1
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_heavy_assault_shield_bastion",
-    "name": "HEAVY ASSAULT SHIELD",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": true
+            {
+                "type": "Kinetic",
+                "damage": [
+                    3,
+                    4,
+                    5
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 1
+            }
+        ],
+        "on_hit": "Target must pass a <strong>Hull</strong> save or be knocked <strong>Prone</strong>."
     },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_knockback",
-        "val": 1
-      }
-    ],
-    "weapon_type": "Heavy Melee",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Kinetic",
+    {
+        "id": "npc-rebake_npcf_friendly_interdiction_bastion",
+        "name": "Friendly Interdiction",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Bastion and one allied character adjacent to it gain <strong>Resistance</strong> to all damage dealt by one character within line of sight. The Bastion may choose a new allied character or a new character to gain <strong>Resistance</strong> from as a <strong>protocol</strong>. The allied character loses <strong>Resistance</strong> if they break adjacency.",
+        "tags": [
+            {
+                "id": "tg_protocol"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_guardian_bastion",
+        "name": "Guardian",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Allied characters can use the Bastion for <strong>hard cover</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_near_threat_denial_system_bastion",
+        "name": "Near-Threat Denial System",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "When characters within <strong>Range 3</strong> attack the Bastion or a character being protected by <strong>Friendly Interdiction</strong>, they take <strong>{2/3/4} AP explosive damage</strong> before rolling.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_siege_guardian_bastion",
+        "name": "Siege Guardian",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Allied characters gain <strong>Resistance</strong> to damage from <strong>Blast</strong>, <strong>Burst</strong>, <strong>Line</strong>, and <strong>Cone</strong> attacks while they’re adjacent to the Bastion.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_fearless_defender_bastion",
+        "name": "Fearless Defender",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Bastion moves to a space adjacent to the triggering character and takes the damage instead. The Bastion may then immediately use <strong>Friendly Interdiction</strong> on the triggering character.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "An allied character in <strong>range 5</strong> of the Bastion takes damage, and the Bastion isn’t <strong>Immobilized</strong>, <strong>Slowed</strong>, <strong>Stunned</strong> or otherwise cannot move."
+    },
+    {
+        "id": "npc-rebake_npcf_deathcounter_bastion",
+        "name": "Deathcounter",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Bastion is wreathed in a crackling energy field visible to all characters. The first time the Bastion is successfully hit by a ranged or melee attack each round, all damage is reduced to <strong>0</strong>, after which the field visibly dissipates until the start of the next round.",
+        "tags": [
+            {
+                "id": "tg_shield"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_stack_up_bastion",
+        "name": "Stack Up",
+        "origin": {
+            "type": "Class",
+            "name": "Bastion [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When the Bastion takes its standard move or <strong>Boosts</strong>, an adjacent allied character can choose to move with them, mirroring their movement. This allied character's movement ignores engagement and does not provoke <strong>reactions</strong>. Each allied character can only move a number of spaces this way each round equal to their <strong>Speed</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_chain_axe_berserker",
+        "name": "Chain Axe",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "<strong>On Critical Hit</strong>: Target becomes <strong>Shredded</strong> until the end of their next turn.",
+        "tags": [],
+        "weapon_type": "Heavy Melee",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          3,
-          4,
-          5
+            {
+                "type": "kinetic",
+                "damage": [
+                    7,
+                    9,
+                    11
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 1
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_stampede_defense_berserker",
+        "name": "Stampede Defense",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Berserker has <strong>Resistance</strong> to all damage unless they are <strong>Impaired</strong>, <strong>Stunned</strong>, <strong>Immobilized</strong>, <strong>Shredded</strong>, <strong>Slowed</strong> or <strong>Exposed</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_aggression_berserker",
+        "name": "Aggression",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "After taking damage for the first time each round, the Berserker must immediately attack a random adjacent character, hostile or allied, with the <strong>Chain Axe</strong>. This attack happens even if the Berserker is reduced to <strong>0 HP</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_avalanche_charge_berserker",
+        "name": "Avalanche Charge",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Berserker moves spaces equal to their <strong>Speed</strong> in a straight line, ignoring reactions and engagement, then attacks a random adjacent character – hostile or allied — with the <strong>Chain Axe</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 1
-      }
-    ],
-    "on_hit": "Target must pass a <strong>Hull</strong> save or be knocked <strong>Prone</strong>."
-  },
-  {
-    "id": "npc-rebake_npcf_friendly_interdiction_bastion",
-    "name": "FRIENDLY INTERDICTION",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": true
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Bastion and one allied character adjacent to it gain <strong>Resistance</strong> to all damage dealt by one character within line of sight. The Bastion may choose a new allied character or a new character to gain <strong>Resistance</strong> from as a <strong>protocol</strong>. The allied character loses <strong>Resistance</strong> if they break adjacency.",
-    "tags": [
-      {
-        "id": "tg_protocol"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_guardian_bastion",
-    "name": "GUARDIAN",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_juggernaut_berserker",
+        "name": "Juggernaut",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When the Berserker uses <strong>Avalanche Charge</strong>, all characters adjacent to the path they follow or adjacent to their final position – hostile and allied – must succeed on a <strong>Hull</strong> save or be knocked <strong>Prone</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Allied characters can use the Bastion for <strong>hard cover</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_near_threat_denial_system_bastion",
-    "name": "NEAR-THREAT DENIAL SYSTEM",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "When characters within <strong>Range 3</strong> attack the Bastion or a character being protected by <strong>Friendly Interdiction</strong>, they take <strong>{2/3/4} AP explosive damage</strong> before rolling.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_siege_guardian_bastion",
-    "name": "SIEGE GUARDIAN",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Allied characters gain <strong>Resistance</strong> to damage from <strong>Blast</strong>, <strong>Burst</strong>, <strong>Line</strong>, and <strong>Cone</strong> attacks while they’re adjacent to the Bastion.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_fearless_defender_bastion",
-    "name": "FEARLESS DEFENDER",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": false
-    },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Bastion moves to a space adjacent to the triggering character and takes the damage instead. The Bastion may then immediately use <strong>Friendly Interdiction</strong> on the triggering character.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "An allied character in <strong>range 5</strong> of the Bastion takes damage, and the Bastion isn’t <strong>Immobilized</strong>, <strong>Slowed</strong>, <strong>Stunned</strong> or otherwise cannot move."
-  },
-  {
-    "id": "npc-rebake_npcf_deathcounter_bastion",
-    "name": "DEATHCOUNTER",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Bastion is wreathed in a crackling energy field visible to all characters. The first time the Bastion is successfully hit by a ranged or melee attack each round, all damage is reduced to <strong>0</strong>, after which the field visibly dissipates until the start of the next round.",
-    "tags": [
-      {
-        "id": "tg_shield"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_stack_up_bastion",
-    "name": "STACK UP",
-    "origin": {
-      "type": "Class",
-      "name": "BASTION",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When the Bastion takes its standard move or <strong>Boosts</strong>, an adjacent allied character can choose to move with them, mirroring their movement. This allied character's movement ignores engagement and does not provoke <strong>reactions</strong>. Each allied character can only move a number of spaces this way each round equal to their <strong>Speed</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_chain_axe_berserker",
-    "name": "CHAIN AXE",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "<strong>On Critical Hit</strong>: Target becomes <strong>Shredded</strong> until the end of their next turn.",
-    "tags": [],
-    "weapon_type": "Heavy Melee",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_harpoon_cannon_berserker",
+        "name": "Harpoon Cannon",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [],
+        "weapon_type": "Main CQB",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          7,
-          9,
-          11
-        ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 1
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_stampede_defense_berserker",
-    "name": "STAMPEDE DEFENSE",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": true
+            {
+                "type": "Kinetic",
+                "damage": [
+                    2,
+                    3,
+                    4
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 5
+            },
+            {
+                "type": "Threat",
+                "val": 3
+            }
+        ],
+        "on_hit": "Targets of smaller or equal <strong>Size</strong> to the Berserker are pulled adjacent to them in a straight line,or as close as possible. If they’re larger, the Berserker is pulled adjacent to them instead. If this ends with the Berserker adjacent to the target, the Berserker <strong>Grapples</strong> them."
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Berserker has <strong>Resistance</strong> to all damage unless they are <strong>Impaired</strong>, <strong>Stunned</strong>, <strong>Immobilized</strong>, <strong>Shredded</strong>, <strong>Slowed</strong> or <strong>Exposed</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_aggression_berserker",
-    "name": "AGGRESSION",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_retribution_berserker",
+        "name": "Retribution",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Whenever the Berserker takes damage, their next attack deals <strong>+1d6 bonus damage</strong>. This bonus damage is lost when the Berserker attacks, or at the end of their next turn.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "After taking damage for the first time each round, the Berserker must immediately attack a random adjacent character, hostile or allied, with the <strong>Chain Axe</strong>. This attack happens even if the Berserker is reduced to <strong>0 HP</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_avalanche_charge_berserker",
-    "name": "AVALANCHE CHARGE",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_headhunter_berserker",
+        "name": "Headhunter",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Whenever the Berserker attacks a target that is <strong>Grappled</strong>, <strong>Immobilized</strong>, <strong>Stunned</strong>, or <strong>Prone</strong> with the <strong>Chain Axe</strong>, they become <strong>Shredded</strong> on hit rather than on critical hit.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Berserker moves spaces equal to their <strong>Speed</strong> in a straight line, ignoring reactions and engagement, then attacks a random adjacent character – hostile or allied — with the <strong>Chain Axe</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_juggernaut_berserker",
-    "name": "JUGGERNAUT",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_overdrive_servos_berserker",
+        "name": "Overdrive Servos",
+        "origin": {
+            "type": "Class",
+            "name": "Berserker [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Berserker counts as <strong>Size 3</strong> for <strong>Ram</strong> and <strong>Grapple</strong>, and they deal <strong>{3/4/5} kinetic damage</strong> on hit with <strong>Ram</strong> and <strong>Grapple</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When the Berserker uses <strong>Avalanche Charge</strong>, all characters adjacent to the path they follow or adjacent to their final position – hostile and allied – must succeed on a <strong>Hull</strong> save or be knocked <strong>Prone</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_harpoon_cannon_berserker",
-    "name": "HARPOON CANNON",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [],
-    "weapon_type": "Main CQB",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "Kinetic",
+    {
+        "id": "npc-rebake_npcf_bombard_cannon_bombard",
+        "name": "Bombard Cannon",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_arcing"
+            },
+            {
+                "id": "tg_ordnance"
+            }
+        ],
+        "weapon_type": "Superheavy Cannon",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
+        "accuracy": [
+            -1,
+            -1,
+            -1
+        ],
         "damage": [
-          2,
-          3,
-          4
+            {
+                "type": "Explosive",
+                "damage": [
+                    5,
+                    7,
+                    9
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 25
+            },
+            {
+                "type": "Blast",
+                "val": 2
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_cluster_munitions_bombard",
+        "name": "Cluster Munitions",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Bombard’s attacks deal <strong>{+2/+3/+4} damage</strong> to all characters for each targeted character beyond the first.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_earthshaker_shells_bombard",
+        "name": "Earthshaker Shells",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may also fire a special earthshaker shell. In addition to any damage, all characters within the <strong>Blast</strong> must pass a <strong>Hull</strong> save or be knocked <strong>Prone</strong>. Debris or broken earth is thrown up by the impact, creating two <strong>Size 1</strong> segments of hard cover in free spaces within <strong>Range 5</strong> of the targeted space. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_siege_armor_bombard",
+        "name": "Siege Armor",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Bombard has <strong>Resistance</strong> to all damage from attacks that originate beyond <strong>range 3</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_high_impact_shells_bombard",
+        "name": "High-Impact Shells",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may fire a special high-impact shell. <strong>On hit</strong>, characters are knocked back <strong>3 spaces</strong> either directly away from the Bombard or away from the center of the <strong>Blast</strong>. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack. Only one type of special shell can be fired at a time.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_bunker_buster_bombard",
+        "name": "Bunker Buster",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may fire a special bunker buster shell. The <strong>Bombard Cannon</strong> automatically deals <strong>{10/20/30} AP explosive damage</strong> to all objects and terrain in the affected area, and the area within the <strong>Blast</strong> also becomes <strong>difficult terrain</strong>. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack. Only one type of special shell can be fired at a time.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_flare_drone_bombard",
+        "name": "Flare Drone",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "<strong>Flare Drone</strong> (<strong>Size</strong> 1/2, <strong>HP</strong> {10/20/30}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags</strong>: Drone)<br>This drone can be deployed to a space within line of sight and <strong>Range 25</strong>, where it hovers in place and begins projecting bright light in a <strong>Burst 2</strong> area. All characters in the affected area – including those that move into the affected area or start their turn within it – lose <strong>Invisible</strong> and <strong>Hidden</strong>, and cannot <strong>Hide</strong> or turn <strong>Invisible</strong> within the area. Additionally, the Bombard gains <strong>+1 Accuracy</strong> to attacks against characters within the affected area (including the drone itself). The Bombard can only have one drone deployed at a time; if a new drone is deployed, the old one disintegrates.",
+        "tags": [
+            {
+                "id": "tg_drone"
+            },
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 5
-      },
-      {
-        "type": "Threat",
-        "val": 3
-      }
-    ],
-    "on_hit": "Targets of smaller or equal <strong>Size</strong> to the Berserker are pulled adjacent to them in a straight line,or as close as possible. If they’re larger, the Berserker is pulled adjacent to them instead. If this ends with the Berserker adjacent to the target, the Berserker <strong>Grapples</strong> them."
-  },
-  {
-    "id": "npc-rebake_npcf_retribution_berserker",
-    "name": "RETRIBUTION",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": false
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Whenever the Berserker takes damage, their next attack deals <strong>+1d6 bonus damage</strong>. This bonus damage is lost when the Berserker attacks, or at the end of their next turn.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_headhunter_berserker",
-    "name": "HEADHUNTER",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_high-angle_fire_bombard",
+        "name": "High-Angle Fire",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Bombard may prepare a delayed, high-angle shot with the <strong>Bombard Cannon</strong>. Choose a <strong>Blast 3</strong> area, which becomes visible to all characters; the Bombard then makes an attack at the end of the next round with the <strong>Bombard Cannon</strong>, after all characters have acted, against every target within the area.",
+        "tags": [
+            {
+                "id": "tg_full_action"
+            },
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Whenever the Berserker attacks a target that is <strong>Grappled</strong>, <strong>Immobilized</strong>, <strong>Stunned</strong>, or <strong>Prone</strong> with the <strong>Chain Axe</strong>, they become <strong>Shredded</strong> on hit rather than on critical hit.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_overdrive_servos_berserker",
-    "name": "OVERDRIVE SERVOS",
-    "origin": {
-      "type": "Class",
-      "name": "BERSERKER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_counterbattery_suite_bombard",
+        "name": "Counterbattery Suite",
+        "origin": {
+            "type": "Class",
+            "name": "Bombard [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The triggering character gains Lock On. This Reaction can't be used against characters within Range 3 of the Bombard.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "A hostile character makes an attack against the Bombard."
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Berserker counts as <strong>Size 3</strong> for <strong>Ram</strong> and <strong>Grapple</strong>, and they deal <strong>{3/4/5} kinetic damage</strong> on hit with <strong>Ram</strong> and <strong>Grapple</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_bombard_cannon_bombard",
-    "name": "BOMBARD CANNON",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_arcing"
-      },
-      {
-        "id": "tg_ordnance"
-      }
-    ],
-    "weapon_type": "Superheavy Cannon",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "accuracy": [
-      -1,
-      -1,
-      -1
-    ],
-    "damage": [
-      {
-        "type": "Explosive",
+    {
+        "id": "npc-rebake_npcf_dual_shotguns_breacher",
+        "name": "Dual Shotguns",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "This weapon can make two attacks at once, targeting either the same character or different ones. The final attack rolls for this weapon can never be affected by <strong>Accuracy</strong>.",
+        "tags": [],
+        "weapon_type": "Main CQB",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
+        "accuracy": [
+            -2,
+            -2,
+            -2
+        ],
         "damage": [
-          5,
-          7,
-          9
+            {
+                "type": "kinetic",
+                "damage": [
+                    5,
+                    7,
+                    9
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 3
+            },
+            {
+                "type": "Threat",
+                "val": 3
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_breach_ram_breacher",
+        "name": "Breach Ram",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Breacher moves up to <strong>6 spaces</strong> in a straight line, ignoring engagement and passing through – but not stopping in – spaces occupied by other characters. Obstructions and objects in the Breacher’s path take <strong>10/20/30 AP kinetic damage</strong>. The Breacher passes through any obstructions destroyed this way and continues moving until they have moved <strong>6 spaces</strong> or fail to destroy an obstruction. Any characters in the Breacher’s path must succeed on an <strong>Agility</strong> save or be pushed out of the way as directly as possible and knocked <strong>Prone</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 25
-      },
-      {
-        "type": "Blast",
-        "val": 2
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_cluster_munitions_bombard",
-    "name": "CLUSTER MUNITIONS",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": true
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Bombard’s attacks deal <strong>{+2/+3/+4} damage</strong> to all characters for each targeted character beyond the first.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_earthshaker_shells_bombard",
-    "name": "EARTHSHAKER SHELLS",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_break_armor_breacher",
+        "name": "Break Armor",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Characters that are successfully attacked more than once in a turn by the Breacher’s <strong>Dual Shotguns</strong> become <strong>Shredded</strong> for the rest of the scene.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may also fire a special earthshaker shell. In addition to any damage, all characters within the <strong>Blast</strong> must pass a <strong>Hull</strong> save or be knocked <strong>Prone</strong>. Debris or broken earth is thrown up by the impact, creating two <strong>Size 1</strong> segments of hard cover in free spaces within <strong>Range 5</strong> of the targeted space. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_siege_armor_bombard",
-    "name": "SIEGE ARMOR",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_ram_plating_breacher",
+        "name": "Ram Plating",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Breacher gains <strong>+1 Accuracy</strong> to Ram.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Bombard has <strong>Resistance</strong> to all damage from attacks that originate beyond <strong>range 3</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_high_impact_shells_bombard",
-    "name": "HIGH-IMPACT SHELLS",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_follower_count_breacher",
+        "name": "Follower Count",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Breacher makes a tech attack against a character within <strong>Sensors</strong>. On a success, the Breacher gains <strong>+1 Accuracy</strong> on all attacks against their target, and may <strong>Boost</strong> once per turn as a <strong>free action</strong> so long as it moves them directly towards their target. This lasts until either character is destroyed and cannot be changed to a new target unless the Breacher takes <strong>4 Heat</strong> to attempt this tech attack against a different target.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may fire a special high-impact shell. <strong>On hit</strong>, characters are knocked back <strong>3 spaces</strong> either directly away from the Bombard or away from the center of the <strong>Blast</strong>. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack. Only one type of special shell can be fired at a time.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_bunker_buster_bombard",
-    "name": "BUNKER BUSTER",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_thermal_charge_breacher",
+        "name": "Thermal Charge",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Breacher may expend a charge to throw a grenade to a space within <strong>Range 5</strong>. Characters in the ensuing <strong>Blast 1</strong> explosion must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and become <strong>Shredded</strong> until the end of their next turn. Objects, terrain, and <strong>Deployables</strong> in the area automatically take <strong>{10/20/30} AP explosive damage</strong>; if any objects or terrain are destroyed this way, the Breacher may immediately move their <strong>Speed</strong> towards one of those spaces or as close as possible.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_grenade"
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "When attacking with the <strong>Bombard Cannon</strong>, the Bombard may fire a special bunker buster shell. The <strong>Bombard Cannon</strong> automatically deals <strong>{10/20/30} AP explosive damage</strong> to all objects and terrain in the affected area, and the area within the <strong>Blast</strong> also becomes <strong>difficult terrain</strong>. The <strong>Bombard Cannon</strong> must then be reloaded before it can be used again (as though it was <strong>Loading</strong>) unless <strong>three or more characters</strong> were targeted by this attack. Only one type of special shell can be fired at a time.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_flare_drone_bombard",
-    "name": "FLARE DRONE",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_painmaker_breacher",
+        "name": "Painmaker",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Breacher prepares a salvo of shells, becoming <strong>Slowed</strong> until the end of their next turn. This effect is visible to everyone. During the Breacher's next turn, the next time they use the <strong>Dual Shotguns</strong>, they may make four attacks at once instead of two.",
+        "tags": [
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "<strong>Flare Drone</strong> (<strong>Size</strong> 1/2, <strong>HP</strong> {10/20/30}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags</strong>: Drone)<br>This drone can be deployed to a space within line of sight and <strong>Range 25</strong>, where it hovers in place and begins projecting bright light in a <strong>Burst 2</strong> area. All characters in the affected area – including those that move into the affected area or start their turn within it – lose <strong>Invisible</strong> and <strong>Hidden</strong>, and cannot <strong>Hide</strong> or turn <strong>Invisible</strong> within the area. Additionally, the Bombard gains <strong>+1 Accuracy</strong> to attacks against characters within the affected area (including the drone itself). The Bombard can only have one drone deployed at a time; if a new drone is deployed, the old one disintegrates.",
-    "tags": [
-      {
-        "id": "tg_drone"
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_high-angle_fire_bombard",
-    "name": "HIGH-ANGLE FIRE",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_fragmentation_shells_breacher",
+        "name": "Fragmentation Shells",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "<strong>1/round</strong>, when the Breacher makes a successful attack with the <strong>Dual Shotguns</strong>, a different character within <strong>Range 3</strong> of the target takes <strong>{2/3/4} kinetic damage</strong> + bonus damage equal to the initial target's <strong>Armor</strong>.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Bombard may prepare a delayed, high-angle shot with the <strong>Bombard Cannon</strong>. Choose a <strong>Blast 3</strong> area, which becomes visible to all characters; the Bombard then makes an attack at the end of the next round with the <strong>Bombard Cannon</strong>, after all characters have acted, against every target within the area.",
-    "tags": [
-      {
-        "id": "tg_full_action"
-      },
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_counterbattery_suite_bombard",
-    "name": "COUNTERBATTERY SUITE",
-    "origin": {
-      "type": "Class",
-      "name": "BOMBARD",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_breach_and_clear_breacher",
+        "name": "Breach and Clear",
+        "origin": {
+            "type": "Class",
+            "name": "Breacher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When using <strong>Breach Ram</strong>, the Breacher may also attack any character in their path with the <strong>Dual Shotguns</strong>. The <strong>Dual Shotguns</strong> only make a single attack against each character this way (rather than making two attacks at once), and these attacks deal half damage on hit.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The triggering character gains Lock On. This Reaction can't be used against characters within Range 3 of the Bombard.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "A hostile character makes an attack against the Bombard."
-  },
-  {
-    "id": "npc-rebake_npcf_dual_shotguns_breacher",
-    "name": "DUAL SHOTGUNS",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "This weapon can make two attacks at once, targeting either the same character or different ones. The final attack rolls for this weapon can never be affected by <strong>Accuracy</strong>.",
-    "tags": [],
-    "weapon_type": "Main CQB",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "accuracy": [
-      -2,
-      -2,
-      -2
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_ram_cannon_cataphract",
+        "name": "Ram Cannon",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "This lance can be used as either a ranged or melee weapon, but not both in the same turn. When used as a ranged weapon, <strong>Critical Hits</strong> cause the target to become <strong>Impaired</strong> until the end of their next turn. When used as a melee weapon, it gains <strong>Knockback 2</strong>.",
+        "tags": [],
+        "weapon_type": "Heavy Melee/Heavy Cannon",
+        "attack_bonus": [
+            0,
+            0,
+            0
+        ],
+        "accuracy": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          5,
-          7,
-          9
+            {
+                "type": "kinetic",
+                "damage": [
+                    5,
+                    7,
+                    9
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 5
+            },
+            {
+                "type": "Threat",
+                "val": 2
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_trample_cataphract",
+        "name": "Trample",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Cataphract ignores engagement and can pass through – but not stop in – spaces occupied by other characters, 1/turn dealing <strong>{2/3/4} kinetic damage</strong> to those characters.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_impale_cataphract",
+        "name": "Impale",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Cataphract moves up to <strong>8 spaces</strong> in a straight line. Pick a character that the Cataphract passed through or ended adjacent to; they must pass a <strong>Hull</strong> save. On a failure, they are <strong>grappled</strong> by the Cataphract and pulled with the Cataphract to the end of their movement. On <strong>Critical Hit</strong> with the <strong>Ram Cannon</strong>, this system automatically <strong>Recharges</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 3
-      },
-      {
-        "type": "Threat",
-        "val": 3
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_breach_ram_breacher",
-    "name": "BREACH RAM",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Breacher moves up to <strong>6 spaces</strong> in a straight line, ignoring engagement and passing through – but not stopping in – spaces occupied by other characters. Obstructions and objects in the Breacher’s path take <strong>10/20/30 AP kinetic damage</strong>. The Breacher passes through any obstructions destroyed this way and continues moving until they have moved <strong>6 spaces</strong> or fail to destroy an obstruction. Any characters in the Breacher’s path must succeed on an <strong>Agility</strong> save or be pushed out of the way as directly as possible and knocked <strong>Prone</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_break_armor_breacher",
-    "name": "BREAK ARMOR",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_point_defense_shield_cataphract",
+        "name": "Point-Defense Shield",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Cataphract has <strong>Resistance</strong> to all damage from the closest hostile character. If multiple characters are equally close, this effect does not apply.",
+        "tags": [
+            {
+                "id": "tg_shield"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Characters that are successfully attacked more than once in a turn by the Breacher’s <strong>Dual Shotguns</strong> become <strong>Shredded</strong> for the rest of the scene.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_ram_plating_breacher",
-    "name": "RAM PLATING",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_electrified_lasso_cataphract",
+        "name": "Electrified Lasso",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "A character in line of sight and <strong>Range 5</strong> must make a <strong>Hull</strong> save. On a failure, they take {2/3/4} Heat and are pulled as close as possible to the Cataphract; if they become adjacent, the Cataphract automatically grapples them.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Breacher gains <strong>+1 Accuracy</strong> to Ram.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_follower_count_breacher",
-    "name": "FOLLOWER COUNT",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_lance_shot_cataphract",
+        "name": "Lance Shot",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Cataphract fires a piercing lance in a <strong>Line 5</strong> path. All characters within the affected area must pass a <strong>Hull</strong> save or be knocked back <strong>3 spaces</strong>. Any character that collides with an obstruction or another character also becomes <strong>Immobilized</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Breacher makes a tech attack against a character within <strong>Sensors</strong>. On a success, the Breacher gains <strong>+1 Accuracy</strong> on all attacks against their target, and may <strong>Boost</strong> once per turn as a <strong>free action</strong> so long as it moves them directly towards their target. This lasts until either character is destroyed and cannot be changed to a new target unless the Breacher takes <strong>4 Heat</strong> to attempt this tech attack against a different target.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_thermal_charge_breacher",
-    "name": "THERMAL CHARGE",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_electromagnetic_bola_cataphract",
+        "name": "Electromagnetic Bola",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "A flying character in <strong>Range 10</strong> must pass an Agility save. On a failure, they are pulled <strong>3 spaces</strong>, land immediately, and become <strong>Immobilized</strong> until the end of their next turn. This counts as falling but without damage.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Breacher may expend a charge to throw a grenade to a space within <strong>Range 5</strong>. Characters in the ensuing <strong>Blast 1</strong> explosion must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and become <strong>Shredded</strong> until the end of their next turn. Objects, terrain, and <strong>Deployables</strong> in the area automatically take <strong>{10/20/30} AP explosive damage</strong>; if any objects or terrain are destroyed this way, the Breacher may immediately move their <strong>Speed</strong> towards one of those spaces or as close as possible.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_grenade"
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_painmaker_breacher",
-    "name": "PAINMAKER",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_charge_cataphract",
+        "name": "Charge",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Cataphract moves spaces equal to their <strong>Speed</strong> in a straight line, ignoring <strong>reactions</strong> and engagement, then attacks a target within <strong>Range</strong> with the <strong>Ram Cannon</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Breacher prepares a salvo of shells, becoming <strong>Slowed</strong> until the end of their next turn. This effect is visible to everyone. During the Breacher's next turn, the next time they use the <strong>Dual Shotguns</strong>, they may make four attacks at once instead of two.",
-    "tags": [
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_fragmentation_shells_breacher",
-    "name": "FRAGMENTATION SHELLS",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_capacitor_discharge_cataphract",
+        "name": "Capacitor Discharge",
+        "origin": {
+            "type": "Class",
+            "name": "Cataphract [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "As long as the Cataphract isn't <strong>Slowed</strong> or <strong>Jammed</strong>, whenever characters make melee attacks against them, they take <strong>{2/3/4} Heat</strong> before rolling.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "<strong>1/round</strong>, when the Breacher makes a successful attack with the <strong>Dual Shotguns</strong>, a different character within <strong>Range 3</strong> of the target takes <strong>{2/3/4} kinetic damage</strong> + bonus damage equal to the initial target's <strong>Armor</strong>.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_breach_and_clear_breacher",
-    "name": "BREACH AND CLEAR",
-    "origin": {
-      "type": "Class",
-      "name": "BREACHER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When using <strong>Breach Ram</strong>, the Breacher may also attack any character in their path with the <strong>Dual Shotguns</strong>. The <strong>Dual Shotguns</strong> only make a single attack against each character this way (rather than making two attacks at once), and these attacks deal half damage on hit.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_ram_cannon_cataphract",
-    "name": "RAM CANNON",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "This lance can be used as either a ranged or melee weapon, but not both in the same turn. When used as a ranged weapon, <strong>Critical Hits</strong> cause the target to become <strong>Impaired</strong> until the end of their next turn. When used as a melee weapon, it gains <strong>Knockback 2</strong>.",
-    "tags": [],
-    "weapon_type": "Heavy Melee/Heavy Cannon",
-    "attack_bonus": [
-      0,
-      0,
-      0
-    ],
-    "accuracy": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_demolition_hammer_demolisher",
+        "name": "Demolition Hammer",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_ap"
+            },
+            {
+                "id": "tg_knockback",
+                "val": 3
+            }
+        ],
+        "weapon_type": "Superheavy Melee",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
+        "accuracy": [
+            -1,
+            -1,
+            -1
+        ],
         "damage": [
-          5,
-          7,
-          9
-        ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 5
-      },
-      {
-        "type": "Threat",
-        "val": 2
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_trample_cataphract",
-    "name": "TRAMPLE",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": true
+            {
+                "type": "Explosive",
+                "damage": [
+                    12,
+                    14,
+                    16
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 2
+            }
+        ],
+        "on_hit": "Targets must succeed on a <strong>Hull</strong> save or be <strong>Stunned</strong> until the end of their next turn."
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Cataphract ignores engagement and can pass through – but not stop in – spaces occupied by other characters, 1/turn dealing <strong>{2/3/4} kinetic damage</strong> to those characters.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_impale_cataphract",
-    "name": "IMPALE",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": true
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Cataphract moves up to <strong>8 spaces</strong> in a straight line. Pick a character that the Cataphract passed through or ended adjacent to; they must pass a <strong>Hull</strong> save. On a failure, they are <strong>grappled</strong> by the Cataphract and pulled with the Cataphract to the end of their movement. On <strong>Critical Hit</strong> with the <strong>Ram Cannon</strong>, this system automatically <strong>Recharges</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_point_defense_shield_cataphract",
-    "name": "POINT-DEFENSE SHIELD",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": true
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Cataphract has <strong>Resistance</strong> to all damage from the closest hostile character. If multiple characters are equally close, this effect does not apply.",
-    "tags": [
-      {
-        "id": "tg_shield"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_electrified_lasso_cataphract",
-    "name": "ELECTRIFIED LASSO",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "A character in line of sight and <strong>Range 5</strong> must make a <strong>Hull</strong> save. On a failure, they take {2/3/4} Heat and are pulled as close as possible to the Cataphract; if they become adjacent, the Cataphract automatically grapples them.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_lance_shot_cataphract",
-    "name": "LANCE SHOT",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Cataphract fires a piercing lance in a <strong>Line 5</strong> path. All characters within the affected area must pass a <strong>Hull</strong> save or be knocked back <strong>3 spaces</strong>. Any character that collides with an obstruction or another character also becomes <strong>Immobilized</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_electromagnetic_bola_cataphract",
-    "name": "ELECTROMAGNETIC BOLA",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "A flying character in <strong>Range 10</strong> must pass an Agility save. On a failure, they are pulled <strong>3 spaces</strong>, land immediately, and become <strong>Immobilized</strong> until the end of their next turn. This counts as falling but without damage.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_charge_cataphract",
-    "name": "CHARGE",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Cataphract moves spaces equal to their <strong>Speed</strong> in a straight line, ignoring <strong>reactions</strong> and engagement, then attacks a target within <strong>Range</strong> with the <strong>Ram Cannon</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_capacitor_discharge_cataphract",
-    "name": "CAPACITOR DISCHARGE",
-    "origin": {
-      "type": "Class",
-      "name": "CATAPHRACT",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "As long as the Cataphract isn't <strong>Slowed</strong> or <strong>Jammed</strong>, whenever characters make melee attacks against them, they take <strong>{2/3/4} Heat</strong> before rolling.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_demolition_hammer_demolisher",
-    "name": "DEMOLITION HAMMER",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_ap"
-      },
-      {
-        "id": "tg_knockback",
-        "val": 3
-      }
-    ],
-    "weapon_type": "Superheavy Melee",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "accuracy": [
-      -1,
-      -1,
-      -1
-    ],
-    "damage": [
-      {
-        "type": "Explosive",
+    {
+        "id": "npc-rebake_npcf_earthshatter_demolisher",
+        "name": "Earthshatter",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "<strong>On Attack</strong>: The Demolisher deals <strong>10/20/30 AP kinetic damage</strong> to an object or piece of terrain within <strong>Range 2</strong>, if there is one. Hit or miss, place a <strong>Size 1</strong> piece of terrain that grants <strong>hard cover</strong> in a free space adjacent to your target. The terrain has <strong>10 HP</strong> and <strong>Evasion 5</strong>.",
+        "tags": [
+            {
+                "id": "tg_thrown",
+                "val": 5
+            },
+            {
+                "id": "tg_knockback",
+                "val": 3
+            }
+        ],
+        "weapon_type": "Heavy Melee",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          12,
-          14,
-          16
-        ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 2
-      }
-    ],
-    "on_hit": "Targets must succeed on a <strong>Hull</strong> save or be <strong>Stunned</strong> until the end of their next turn."
-  },
-  {
-    "id": "npc-rebake_npcf_earthshatter_demolisher",
-    "name": "EARTHSHATTER",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": true
+            {
+                "type": "Kinetic",
+                "damage": [
+                    5,
+                    6,
+                    7
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 2
+            }
+        ],
+        "on_hit": ""
     },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "<strong>On Attack</strong>: The Demolisher deals <strong>10/20/30 AP kinetic damage</strong> to an object or piece of terrain within <strong>Range 2</strong>, if there is one. Hit or miss, place a <strong>Size 1</strong> piece of terrain that grants <strong>hard cover</strong> in a free space adjacent to your target. The terrain has <strong>10 HP</strong> and <strong>Evasion 5</strong>.",
-    "tags": [
-      {
-        "id": "tg_thrown",
-        "val": 5
-      },
-      {
-        "id": "tg_knockback",
-        "val": 3
-      }
-    ],
-    "weapon_type": "Heavy Melee",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Kinetic",
+    {
+        "id": "npc-rebake_npcf_shock_armor_demolisher",
+        "name": "Shock Armor",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Demolisher has <strong>Resistance to damage from melee weapons</strong>.",
+        "resistance": [
+            "Melee"
+        ],
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_heavy_frame_demolisher",
+        "name": "Heavy Frame",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Demolisher can’t be pushed, pulled, knocked <strong>Prone</strong>, or knocked back by smaller characters.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_jet_propulsion_demolisher",
+        "name": "Jet Propulsion",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "Whenever the Demolisher makes an attack with the <strong>Demolition Hammer</strong>, it may take <strong>4 Heat</strong> to move <strong>4 spaces</strong> in a straight line directly towards the target before the attack.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_kinetic_compensation_demolisher",
+        "name": "Kinetic Compensation",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Each time the Demolisher misses with the <strong>Demolition Hammer</strong>, they gain <strong>+1 Accuracy</strong> on all subsequent attacks with it until they hit. This <strong>Accuracy</strong> can be gained multiple times and stacks.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_seismic_destroyer_demolisher",
+        "name": "Seismic Destroyer",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "Unless they can fly, all characters in a <strong>Cone 5</strong> area pass an <strong>Agility</strong> save or be knocked <strong>Prone</strong>. All objects and terrain within this area takes <strong>{10/20/30} AP kinetic damage</strong>; if any terrain or objects are destroyed this way, all affected characters also automatically take <strong>{4/6/8} kinetic damage</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_hullcracker_demolisher",
+        "name": "Hullcracker",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Demolisher chooses a character within <strong>Range 2</strong>: they must pass a <strong>Hull</strong> save or be <strong>Immobilized</strong> and <strong>Shredded</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
+    },
+    {
+        "id": "npc-rebake_npcf_drag_cables_demolisher",
+        "name": "Drag Cables",
+        "origin": {
+            "type": "Class",
+            "name": "Demolisher [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Demolisher chooses a character within <strong>Range 5</strong>; that character must pass a <strong>Hull</strong> save or become embedded with high-tensile cable anchors. If the target is Stunned, they automatically fail this save. While these anchors are embedded, neither the target nor the Demolisher can move more than <strong>5 spaces</strong> away from one another. If the target is smaller than the Demolisher, they move when the Demolisher moves, mirroring their movements. The Demolisher can activate this system again and force an embedded character to pass another <strong>Hull</strong> save or be pulled adjacent to the Demolisher.<br>An embedded character can remove the cables on a hit with a <strong>melee attack</strong> against <strong>Evasion 10</strong>. Otherwise, this effect lasts until the end of the scene, until either character is destroyed, or until the Demolisher uses this system on a new target.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_flak_cannon_engineer",
+        "name": "Flak Cannon",
+        "origin": {
+            "type": "Class",
+            "name": "Engineer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "This weapon gains <strong>+1 Accuracy</strong> against <strong>flying</strong> targets.",
+        "tags": [
+            {
+                "id": "tg_smart"
+            }
+        ],
+        "weapon_type": "Heavy Cannon",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          5,
-          6,
-          7
+            {
+                "type": "Explosive",
+                "damage": [
+                    3,
+                    4,
+                    5
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 15
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_deployable_turret_engineer",
+        "name": "Deployable Turret",
+        "origin": {
+            "type": "Class",
+            "name": "Engineer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "Deployable Turret (<strong>Size</strong> 1/2, <strong>HP</strong> {1/1/1}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags:</strong> Drone)<br>Up to two of these self-constructing turrets can be deployed to any free space within <strong>Range 3</strong>. At the end of Engineer’s turn, deployed turrets attack the nearest hostile character within <strong>Range 10</strong>. They attack at +{1/2/3} and deal <strong>{4/5/6} Kinetic damage</strong>. The Engineer may have six turrets deployed at one time; if they deploy additional turrets beyond this, previous turrets of their choice are destroyed until they have no more than six total.<br>All turrets are destroyed when the Engineer is destroyed. If the Engineer becomes <strong>Jammed</strong> or <strong>Stunned</strong>, their turrets are also disabled for the duration of those conditions.",
+        "tags": [
+            {
+                "id": "tg_drone"
+            },
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 2
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_shock_armor_demolisher",
-    "name": "SHOCK ARMOR",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": true
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Demolisher has <strong>Resistance to damage from melee weapons</strong>.",
-    "resistance": [
-      "Melee"
-    ],
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_heavy_frame_demolisher",
-    "name": "HEAVY FRAME",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_target_designator_engineer",
+        "name": "Target Designator",
+        "origin": {
+            "type": "Class",
+            "name": "Engineer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Engineer chooses a character within line of sight and <strong>Sensors</strong>; they gain <strong>Lock On</strong>. At the end of the Engineer's turn, up to two of their <strong>Deployable Turrets</strong> will attack that target (if it is within range) instead of attacking the nearest hostile character.<br>This trait automatically <strong>recharges</strong> whenever two or more <strong>Deployable Turrets</strong> are destroyed by hostile characters before the end of the Engineer's next turn.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Demolisher can’t be pushed, pulled, knocked <strong>Prone</strong>, or knocked back by smaller characters.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_jet_propulsion_demolisher",
-    "name": "JET PROPULSION",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_deployable_fortifications_engineer",
+        "name": "Deployable Fortifications",
+        "origin": {
+            "type": "Class",
+            "name": "Engineer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "<strong>Deployable Turrets</strong> are <strong>Size 1</strong>, and adjacent allied characters can use them for <strong>hard cover</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "Whenever the Demolisher makes an attack with the <strong>Demolition Hammer</strong>, it may take <strong>4 Heat</strong> to move <strong>4 spaces</strong> in a straight line directly towards the target before the attack.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_kinetic_compensation_demolisher",
-    "name": "KINETIC COMPENSATION",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_perimeter_defense_engineer",
+        "name": "Perimiter Defense",
+        "origin": {
+            "type": "Class",
+            "name": "Engineer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "<strong>Deployable Turrets</strong> gain <strong>Threat 3</strong> and can <strong>Overwatch</strong> (1/round per turret), and the Engineer gains the <strong>Auto-Tracking</strong> reaction.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Each time the Demolisher misses with the <strong>Demolition Hammer</strong>, they gain <strong>+1 Accuracy</strong> on all subsequent attacks with it until they hit. This <strong>Accuracy</strong> can be gained multiple times and stacks.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_seismic_destroyer_demolisher",
-    "name": "SEISMIC DESTROYER",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_auto_tracking_engineer",
+        "name": "Auto-Tracking",
+        "origin": {
+            "type": "Reaction",
+            "name": "Engineer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The <strong>Deployable Turret</strong> makes an attack against the triggering character's target, as long as the target is within line of sight and <strong>Range</strong>.",
+        "tags": [],
+        "trigger": "An allied character within <strong>Range 3</strong> of a <strong>Deployable Turret</strong> makes a successful attack."
     },
-    "locked": false,
-    "type": "System",
-    "effect": "Unless they can fly, all characters in a <strong>Cone 5</strong> area pass an <strong>Agility</strong> save or be knocked <strong>Prone</strong>. All objects and terrain within this area takes <strong>{10/20/30} AP kinetic damage</strong>; if any terrain or objects are destroyed this way, all affected characters also automatically take <strong>{4/6/8} kinetic damage</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_hullcracker_demolisher",
-    "name": "HULLCRACKER",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_mobile_turrets_engineer",
+        "name": "Mobile Turrets",
+        "origin": {
+            "type": "Class",
+            "name": "Engineer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "At the start of the Engineer’s turn, they may move two <strong>Deployable Turrets</strong> up to <strong>3 spaces</strong> in any direction.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Demolisher chooses a character within <strong>Range 2</strong>: they must pass a <strong>Hull</strong> save or be <strong>Immobilized</strong> and <strong>Shredded</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_drag_cables_demolisher",
-    "name": "DRAG CABLES",
-    "origin": {
-      "type": "Class",
-      "name": "DEMOLISHER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_skyshield_protocol_engineer",
+        "name": "Skyshield Protocol",
+        "origin": {
+            "type": "Class",
+            "name": "Engineer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Deployable Turrets gain <strong>+1 Accuracy</strong> against <strong>flying</strong> targets.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Demolisher chooses a character within <strong>Range 5</strong>; that character must pass a <strong>Hull</strong> save or become embedded with high-tensile cable anchors. If the target is Stunned, they automatically fail this save. While these anchors are embedded, neither the target nor the Demolisher can move more than <strong>5 spaces</strong> away from one another. If the target is smaller than the Demolisher, they move when the Demolisher moves, mirroring their movements. The Demolisher can activate this system again and force an embedded character to pass another <strong>Hull</strong> save or be pulled adjacent to the Demolisher.<br>An embedded character can remove the cables on a hit with a <strong>melee attack</strong> against <strong>Evasion 10</strong>. Otherwise, this effect lasts until the end of the scene, until either character is destroyed, or until the Demolisher uses this system on a new target.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_flak_cannon_engineer",
-    "name": "FLAK CANNON",
-    "origin": {
-      "type": "Class",
-      "name": "ENGINEER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_repurpose_engineer",
+        "name": "Repurpose",
+        "origin": {
+            "type": "Class",
+            "name": "Engineer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Engineer chooses an allied character adjacent to one of their <strong>Deployable Turrets</strong>; that character either gains {3/4/5} <strong>Overshield</strong> or gains <strong>+1 Accuracy</strong> on all attacks, checks and saves until the end of their next turn. The turret is then destroyed.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "This weapon gains <strong>+1 Accuracy</strong> against <strong>flying</strong> targets.",
-    "tags": [{
-      "id": "tg_smart"
-    }],
-    "weapon_type": "Heavy Cannon",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [{
-      "type": "Explosive",
-      "damage": [
-        3,
-        4,
-        5
-      ]
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "on_hit": ""
-  },
-
-  {
-    "id": "npc-rebake_npcf_deployable_turret_engineer",
-    "name": "DEPLOYABLE TURRET",
-    "origin": {
-      "type": "Class",
-      "name": "ENGINEER",
-      "base": true
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "Deployable Turret (<strong>Size</strong> 1/2, <strong>HP</strong> {1/1/1}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags:</strong> Drone)<br>Up to two of these self-constructing turrets can be deployed to any free space within <strong>Range 3</strong>. At the end of Engineer’s turn, deployed turrets attack the nearest hostile character within <strong>Range 10</strong>. They attack at +{1/2/3} and deal <strong>{4/5/6} Kinetic damage</strong>. The Engineer may have six turrets deployed at one time; if they deploy additional turrets beyond this, previous turrets of their choice are destroyed until they have no more than six total.<br>All turrets are destroyed when the Engineer is destroyed. If the Engineer becomes <strong>Jammed</strong> or <strong>Stunned</strong>, their turrets are also disabled for the duration of those conditions.",
-    "tags": [{
-        "id": "tg_drone"
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_target_designator_engineer",
-    "name": "TARGET DESIGNATOR",
-    "origin": {
-      "type": "Class",
-      "name": "ENGINEER",
-      "base": true
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Engineer chooses a character within line of sight and <strong>Sensors</strong>; they gain <strong>Lock On</strong>. At the end of the Engineer's turn, up to two of their <strong>Deployable Turrets</strong> will attack that target (if it is within range) instead of attacking the nearest hostile character.<br>This trait automatically <strong>recharges</strong> whenever two or more <strong>Deployable Turrets</strong> are destroyed by hostile characters before the end of the Engineer's next turn.",
-    "tags": [{
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_deployable_fortifications_engineer",
-    "name": "DEPLOYABLE FORTIFICATIONS",
-    "origin": {
-      "type": "Class",
-      "name": "ENGINEER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "<strong>Deployable Turrets</strong> are <strong>Size 1</strong>, and adjacent allied characters can use them for <strong>hard cover</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_perimeter_defense_engineer",
-    "name": "PERIMITER DEFENSE",
-    "origin": {
-      "type": "Class",
-      "name": "ENGINEER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "<strong>Deployable Turrets</strong> gain <strong>Threat 3</strong> and can <strong>Overwatch</strong> (1/round per turret), and the Engineer gains the <strong>Auto-Tracking</strong> reaction.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_auto_tracking_engineer",
-    "name": "AUTO-TRACKING",
-    "origin": {
-      "type": "Reaction",
-      "name": "ENGINEER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The <strong>Deployable Turret</strong> makes an attack against the triggering character's target, as long as the target is within line of sight and <strong>Range</strong>.",
-    "tags": [],
-    "trigger": "An allied character within <strong>Range 3</strong> of a <strong>Deployable Turret</strong> makes a successful attack."
-  },
-  {
-    "id": "npc-rebake_npcf_mobile_turrets_engineer",
-    "name": "MOBILE TURRETS",
-    "origin": {
-      "type": "Class",
-      "name": "ENGINEER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "At the start of the Engineer’s turn, they may move two <strong>Deployable Turrets</strong> up to <strong>3 spaces</strong> in any direction.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_skyshield_protocol_engineer",
-    "name": "SKYSHIELD PROTOCOL",
-    "origin": {
-      "type": "Class",
-      "name": "ENGINEER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Deployable Turrets gain <strong>+1 Accuracy</strong> against <strong>flying</strong> targets.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_repurpose_engineer",
-    "name": "REPURPOSE",
-    "origin": {
-      "type": "Class",
-      "name": "ENGINEER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Engineer chooses an allied character adjacent to one of their <strong>Deployable Turrets</strong>; that character either gains {3/4/5} <strong>Overshield</strong> or gains <strong>+1 Accuracy</strong> on all attacks, checks and saves until the end of their next turn. The turret is then destroyed.",
-    "tags": [{
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_drum_shotgun_goliath",
-    "name": "DRUM SHOTGUN",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "This weapon ignores ranged penalties from <strong>Engaged</strong>.",
-    "tags": [],
-    "weapon_type": "Heavy CQB",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_drum_shotgun_goliath",
+        "name": "Drum Shotgun",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "This weapon ignores ranged penalties from <strong>Engaged</strong>.",
+        "tags": [],
+        "weapon_type": "Heavy CQB",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          5,
-          6,
-          7
+            {
+                "type": "kinetic",
+                "damage": [
+                    5,
+                    6,
+                    7
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 5
+            },
+            {
+                "type": "Threat",
+                "val": 3
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_crush_targeting_goliath",
+        "name": "Crush Targeting",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "A hostile character within Sensors and line of sight gains <strong>+3 Difficulty</strong> to attack against any character other than the Goliath until the start of the Goliath’s next turn. This effect does not stack, and the effect ends immediately if the Goliath becomes <strong>Jammed</strong> or <strong>Stunned</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            }
+        ],
+        "tech_type": "Quick"
+    },
+    {
+        "id": "npc-rebake_npcf_towering_stride_goliath",
+        "name": "Towering Stride",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Goliath can end its turn overlapping obstructions, cover, and terrain smaller than <strong>Size 3</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_heavy_frame_goliath",
+        "name": "Heavy Frame",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Goliath can’t be pushed, pulled, knocked <strong>Prone</strong>, or knocked back by smaller characters.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_guardian_goliath",
+        "name": "Guardian",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Adjacent allied characters can use the Goliath for <strong>hard cover</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_power_knuckle_goliath",
+        "name": "Power Knuckle",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "A character within <strong>Range 2</strong> must pass a <strong>Hull</strong> save or take <strong>{4/5/6} Kinetic damage</strong>, be pushed <strong>5 spaces</strong> directly away from the Goliath, and knocked <strong>Prone</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 5
-      },
-      {
-        "type": "Threat",
-        "val": 3
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_crush_targeting_goliath",
-    "name": "CRUSH TARGETING",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": true
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "A hostile character within Sensors and line of sight gains <strong>+3 Difficulty</strong> to attack against any character other than the Goliath until the start of the Goliath’s next turn. This effect does not stack, and the effect ends immediately if the Goliath becomes <strong>Jammed</strong> or <strong>Stunned</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      }
-    ],
-    "tech_type": "Quick"
-  },
-  {
-    "id": "npc-rebake_npcf_towering_stride_goliath",
-    "name": "TOWERING STRIDE",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_pin_goliath",
+        "name": "Pin",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "A character within <strong>Range 2</strong> becomes <strong>Immobilized</strong> and <strong>Impaired</strong> until they either damage the Goliath, the Goliath is <strong>Stunned</strong> or destroyed, or the Goliath targets another character with this effect. The Goliath is <strong>Immobilized</strong> for the duration of this effect.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Goliath can end its turn overlapping obstructions, cover, and terrain smaller than <strong>Size 3</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_heavy_frame_goliath",
-    "name": "HEAVY FRAME",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_mag_gauntlet_goliath",
+        "name": "Mag Gauntlet",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "A character within <strong>Sensors</strong> and line of sight must pass a <strong>Hull</strong> save or be pulled <strong>3 spaces</strong> towards the Goliath. If they are pulled adjacent to the Goliath, they automatically become grappled. The Goliath can only grapple one character this way at a time, and can't use this system while grappling someone this way.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Goliath can’t be pushed, pulled, knocked <strong>Prone</strong>, or knocked back by smaller characters.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_guardian_goliath",
-    "name": "GUARDIAN",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_coercive_force_goliath",
+        "name": "Coercive Force",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "All characters of the Goliath's choice within <strong>Sensors</strong> are pulled <strong>2 spaces</strong> towards the Goliath.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_tech"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Adjacent allied characters can use the Goliath for <strong>hard cover</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_power_knuckle_goliath",
-    "name": "POWER KNUCKLE",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_attractor_field_goliath",
+        "name": "Attractor Field",
+        "origin": {
+            "type": "Class",
+            "name": "Goliath [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Goliath becomes the target of the attack instead. If the attack was an area of effect, such as a <strong>Line</strong>, <strong>Cone</strong>, <strong>Blast</strong>, etc, the attacker must now position it so it targets the Goliath, or as close as possible, which could change its targets. This transfer takes place even if the attack could not have hit the Goliath (i.e. it was a melee attack).",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "An allied character within <strong>Range 2</strong> and line of sight is targeted by an attack dealing <strong>kinetic</strong> or <strong>explosive</strong> damage."
     },
-    "locked": false,
-    "type": "System",
-    "effect": "A character within <strong>Range 2</strong> must pass a <strong>Hull</strong> save or take <strong>{4/5/6} Kinetic damage</strong>, be pushed <strong>5 spaces</strong> directly away from the Goliath, and knocked <strong>Prone</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_pin_goliath",
-    "name": "PIN",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "A character within <strong>Range 2</strong> becomes <strong>Immobilized</strong> and <strong>Impaired</strong> until they either damage the Goliath, the Goliath is <strong>Stunned</strong> or destroyed, or the Goliath targets another character with this effect. The Goliath is <strong>Immobilized</strong> for the duration of this effect.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_mag_gauntlet_goliath",
-    "name": "MAG GAUNTLET",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": false
-    },
-    "locked": false,
-    "type": "Tech",
-    "effect": "A character within <strong>Sensors</strong> and line of sight must pass a <strong>Hull</strong> save or be pulled <strong>3 spaces</strong> towards the Goliath. If they are pulled adjacent to the Goliath, they automatically become grappled. The Goliath can only grapple one character this way at a time, and can't use this system while grappling someone this way.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_coercive_force_goliath",
-    "name": "COERCIVE FORCE",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "All characters of the Goliath's choice within <strong>Sensors</strong> are pulled <strong>2 spaces</strong> towards the Goliath.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_tech"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_attractor_field_goliath",
-    "name": "ATTRACTOR FIELD",
-    "origin": {
-      "type": "Class",
-      "name": "GOLIATH",
-      "base": false
-    },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Goliath becomes the target of the attack instead. If the attack was an area of effect, such as a <strong>Line</strong>, <strong>Cone</strong>, <strong>Blast</strong>, etc, the attacker must now position it so it targets the Goliath, or as close as possible, which could change its targets. This transfer takes place even if the attack could not have hit the Goliath (i.e. it was a melee attack).",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "An allied character within <strong>Range 2</strong> and line of sight is targeted by an attack dealing <strong>kinetic</strong> or <strong>explosive</strong> damage."
-  },
-  {
-    "id": "npc-rebake_npcf_hunter_killer_nexus_hive",
-    "name": "HUNTER-KILLER NEXUS",
-    "origin": {
-      "type": "Class",
-      "name": "HIVE",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_smart"
-      },
-      {
-        "id": "tg_seeking"
-      }
-    ],
-    "weapon_type": "Main Nexus",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "Burn",
+    {
+        "id": "npc-rebake_npcf_hunter_killer_nexus_hive",
+        "name": "Hunter-Killer Nexus",
+        "origin": {
+            "type": "Class",
+            "name": "Hive [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_smart"
+            },
+            {
+                "id": "tg_seeking"
+            }
+        ],
+        "weapon_type": "Main Nexus",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          2,
-          3,
-          4
+            {
+                "type": "Burn",
+                "damage": [
+                    2,
+                    3,
+                    4
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 10
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_razor_swarm_hive",
+        "name": "Razor Swarm",
+        "origin": {
+            "type": "Class",
+            "name": "Hive [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Hive deploys a <strong>Blast 1</strong> razor swarm in a free area within <strong>Sensors</strong>. Allied characters gain <strong>soft cover</strong> as long as they are at least partially within the affected area. Hostile characters start their turn at least partially within the area or move into it for the first time in a round take <strong>{2/3/4} Burn</strong>. At the start of the Hive's turn, they may move the <strong>Razor Swarm</strong> up to <strong>2 spaces</strong> in any direction, including into spaces occupied by other characters. Only a single <strong>Razor Swarm</strong> may be deployed at a time, and if a new one is deployed (or the Hive is destroyed) the old one is destroyed.",
+        "tags": [
+            {
+                "id": "tg_drone"
+            },
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 10
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_razor_swarm_hive",
-    "name": "RAZOR SWARM",
-    "origin": {
-      "type": "Class",
-      "name": "HIVE",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Hive deploys a <strong>Blast 1</strong> razor swarm in a free area within <strong>Sensors</strong>. Allied characters gain <strong>soft cover</strong> as long as they are at least partially within the affected area. Hostile characters start their turn at least partially within the area or move into it for the first time in a round take <strong>{2/3/4} Burn</strong>. At the start of the Hive's turn, they may move the <strong>Razor Swarm</strong> up to <strong>2 spaces</strong> in any direction, including into spaces occupied by other characters. Only a single <strong>Razor Swarm</strong> may be deployed at a time, and if a new one is deployed (or the Hive is destroyed) the old one is destroyed.",
-    "tags": [
-      {
-        "id": "tg_drone"
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_drone_barrage_hive",
-    "name": "DRONE BARRAGE",
-    "origin": {
-      "type": "Class",
-      "name": "HIVE",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_drone_barrage_hive",
+        "name": "Drone Barrage",
+        "origin": {
+            "type": "Class",
+            "name": "Hive [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Hive makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target chooses one: they become <strong>Immobilized</strong> and <strong>Impaired</strong> until the end of their next turn, or they immediately move up to <strong>4 spaces</strong> in a direction chosen by the Hive. This movement ignores engagement and does not provoke <strong>reactions</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Hive makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target chooses one: they become <strong>Immobilized</strong> and <strong>Impaired</strong> until the end of their next turn, or they immediately move up to <strong>4 spaces</strong> in a direction chosen by the Hive. This movement ignores engagement and does not provoke <strong>reactions</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_driving_swarm_hive",
-    "name": "DRIVING SWARM",
-    "origin": {
-      "type": "Class",
-      "name": "HIVE",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_driving_swarm_hive",
+        "name": "Driving Swarm",
+        "origin": {
+            "type": "Class",
+            "name": "Hive [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Whenever characters take <strong>Burn</strong> from a <strong>Razor Swarm</strong>, they must pass a <strong>Systems</strong> save or immediately move <strong>4 spaces</strong> in a direction chosen by the Hive after taking damage. This movement ignores engagement and does not provoke <strong>reactions</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Whenever characters take <strong>Burn</strong> from a <strong>Razor Swarm</strong>, they must pass a <strong>Systems</strong> save or immediately move <strong>4 spaces</strong> in a direction chosen by the Hive after taking damage. This movement ignores engagement and does not provoke <strong>reactions</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_harrier_maniple_hive",
-    "name": "HARRIER MANIPLE",
-    "origin": {
-      "type": "Class",
-      "name": "HIVE",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_harrier_maniple_hive",
+        "name": "Harrier Maniple",
+        "origin": {
+            "type": "Class",
+            "name": "Hive [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Hive releases a swarm of tiny drones and makes a tech attack against a hostile character within <strong>Sensors</strong>. On a success, the Hive pushes the target up to <strong>2 spaces</strong> in a direction of their choice and the drones create a swarming <strong>Burst 2</strong> area centered around them that lasts until the end of their next turn. All other hostile characters that start their turn at least partially within the area or move into it for the first time in a round take <strong>{2/3/4} Burn</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Hive releases a swarm of tiny drones and makes a tech attack against a hostile character within <strong>Sensors</strong>. On a success, the Hive pushes the target up to <strong>2 spaces</strong> in a direction of their choice and the drones create a swarming <strong>Burst 2</strong> area centered around them that lasts until the end of their next turn. All other hostile characters that start their turn at least partially within the area or move into it for the first time in a round take <strong>{2/3/4} Burn</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_solipsis_swarm_hive",
-    "name": "SOLIPSIS SWARM",
-    "origin": {
-      "type": "Class",
-      "name": "HIVE",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_solipsis_swarm_hive",
+        "name": "Solipsis Swarm",
+        "origin": {
+            "type": "Class",
+            "name": "Hive [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "At the start of their turn, characters within <strong>Range 3</strong> of the Hive take <strong>{2/3/4} Burn</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "At the start of their turn, characters within <strong>Range 3</strong> of the Hive take <strong>{2/3/4} Burn</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_electro_nanite_payloads_hive",
-    "name": "ELECTRO-NANITE PAYLOADS",
-    "origin": {
-      "type": "Class",
-      "name": "HIVE",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_electro_nanite_payloads_hive",
+        "name": "Electro-Nanite Payloads",
+        "origin": {
+            "type": "Class",
+            "name": "Hive [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Until the end of their next turn, any character that takes <strong>Burn</strong> from the Hive or a <strong>Razor Swarm</strong> makes all checks and saves at <strong>+1 Difficulty</strong>, and all Tech Attacks are made against them with <strong>+1 Accuracy</strong>. This effect of this trait does not stack.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Until the end of their next turn, any character that takes <strong>Burn</strong> from the Hive or a <strong>Razor Swarm</strong> makes all checks and saves at <strong>+1 Difficulty</strong>, and all Tech Attacks are made against them with <strong>+1 Accuracy</strong>. This effect of this trait does not stack.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_command_override_hive",
-    "name": "COMMAND OVERRIDE",
-    "origin": {
-      "type": "Class",
-      "name": "HIVE",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_command_override_hive",
+        "name": "Command Override",
+        "origin": {
+            "type": "Class",
+            "name": "Hive [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Hive chooses up to three <strong>Drones</strong> within <strong>Sensors</strong> (including those belonging to other characters) and moves them <strong>3 spaces</strong> in any direction. Then all characters adjacent to any of those <strong>Drones</strong> must pass a <strong>Systems</strong> save or take <strong>{2/3/4} Burn</strong> and gain <strong>Lock On</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            },
+            {
+                "id": "tg_heat_self",
+                "val": 4
+            },
+            {
+                "id": "tg_recharge",
+                "val": 5
+            }
+        ],
+        "tech_type": "Quick"
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Hive chooses up to three <strong>Drones</strong> within <strong>Sensors</strong> (including those belonging to other characters) and moves them <strong>3 spaces</strong> in any direction. Then all characters adjacent to any of those <strong>Drones</strong> must pass a <strong>Systems</strong> save or take <strong>{2/3/4} Burn</strong> and gain <strong>Lock On</strong>. This counts as taking <strong>Burn</strong> from a <strong>Razor Swarm</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      },
-      {
-        "id": "tg_heat_self",
-        "val": 4
-      },
-      {
-        "id": "tg_recharge",
-        "val": 5
-      }
-    ],
-    "tech_type": "Quick"
-  },
-  {
-    "id": "npc-rebake_npcf_stinger_pistol_hornet",
-    "name": "STINGER PISTOL",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [],
-    "weapon_type": "Auxiliary CQB",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ],
-    "damage": [
-      {
-        "type": "Energy",
+    {
+        "id": "npc-rebake_npcf_stinger_pistol_hornet",
+        "name": "Stinger Pistol",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [],
+        "weapon_type": "Auxiliary CQB",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ],
         "damage": [
-          1,
-          2,
-          3
+            {
+                "type": "Energy",
+                "damage": [
+                    1,
+                    2,
+                    3
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 5
+            },
+            {
+                "type": "Threat",
+                "val": 3
+            }
+        ],
+        "on_hit": "Targets become <strong>Impaired</strong> until the end of their next turn."
+    },
+    {
+        "id": "npc-rebake_npcf_ssc_total_suite_hornet",
+        "name": "SSC Total Suite",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Hornet can <strong>hover</strong> whenever they move.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_weave_hornet",
+        "name": "Weave",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Each round, the first attack made against the Hornet as a <strong>reaction</strong> automatically fails.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_impale_systems_hornet",
+        "name": "Impale Systems",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Hornet makes a tech attack against a character within <strong>Sensors</strong>. On a hit, they take <strong>{3/4/5} Heat</strong> and become <strong>Jammed</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_tech"
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            2,
+            4,
+            6
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 5
-      },
-      {
-        "type": "Threat",
-        "val": 3
-      }
-    ],
-    "on_hit": "Targets become <strong>Impaired</strong> until the end of their next turn."
-  },
-  {
-    "id": "npc-rebake_npcf_ssc_total_suite_hornet",
-    "name": "SSC TOTAL SUITE",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Hornet can <strong>hover</strong> whenever they move.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_weave_hornet",
-    "name": "WEAVE",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_supersonic_hornet",
+        "name": "Supersonic",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Hornet flies to a space in line of sight and <strong>Range 50</strong> so impossibly fast that it counts as <strong>teleportation</strong>. If they end this movement within <strong>Range 5</strong> of another character, that character becomes <strong>Impaired</strong> until the end of their next turn and this ability automatically recharges; If multiple characters are within <strong>Range 5</strong>, the Hornet chooses one of them.",
+        "tags": [
+            {
+                "id": "tg_full_action"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 6
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Each round, the first attack made against the Hornet as a <strong>reaction</strong> automatically fails.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_impale_systems_hornet",
-    "name": "IMPALE SYSTEMS",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_umbral_interdiction_hornet",
+        "name": "Umbral Interdiction",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "If the target is not <strong>Impaired</strong>, they immediately become <strong>Impaired</strong> until the end of their next turn. If the target is <strong>Impaired</strong>, they must pass a <strong>Systems</strong> check or their attack automatically misses.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "A character within <strong>Sensors</strong> and line of sight attempts an attack."
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Hornet makes a tech attack against a character within <strong>Sensors</strong>. On a hit, they take <strong>{3/4/5} Heat</strong> and become <strong>Jammed</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_tech"
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_supersonic_hornet",
-    "name": "SUPERSONIC",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_system_spike_hornet",
+        "name": "System Spike",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Hostile <strong>Impaired</strong> characters within the Hornet's <strong>Sensors</strong> recieve <strong>+2 Difficulty</strong> on all attacks, checks, and saves instead of <strong>+1 Difficulty</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Hornet flies to a space in line of sight and <strong>Range 50</strong> so impossibly fast that it counts as <strong>teleportation</strong>. If they end this movement within <strong>Range 5</strong> of another character, that character becomes <strong>Impaired</strong> until the end of their next turn and this ability automatically recharges; If multiple characters are within <strong>Range 5</strong>, the Hornet chooses one of them.",
-    "tags": [
-      {
-        "id": "tg_full_action"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 6
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_umbral_interdiction_hornet",
-    "name": "UMBRAL INTERDICTION",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_slingshot_hornet",
+        "name": "Slingshot",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Hornet makes a Tech Attack against a target in <strong>Sensors</strong>. On a success, they take <strong>{3/4/5} Heat</strong> and are pushed <strong>3 spaces</strong> in a direction of the Hornet's choice, then the Hornet moves to a free space within <strong>Range 5</strong> of the target as directly as possible.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 5
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ]
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "If the target is not <strong>Impaired</strong>, they immediately become <strong>Impaired</strong> until the end of their next turn. If the target is <strong>Impaired</strong>, they must pass a <strong>Systems</strong> check or their attack automatically misses.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "A character within <strong>Sensors</strong> and line of sight attempts an attack."
-  },
-  {
-    "id": "npc-rebake_npcf_system_spike_hornet",
-    "name": "SYSTEM SPIKE",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_lock_hold_javelins_hornet",
+        "name": "Lock/Hold Javelins",
+        "origin": {
+            "type": "Class",
+            "name": "Hornet [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Hornet fires a javelin at a character within <strong>Range 5</strong> and line of sight. The target must succeed on a <strong>Hull</strong> save or be impaled, at which point the javelin tethers itself and its victim to the ground (or another surface), rendering them <strong>Immobilized</strong> and <strong>Shredded</strong>. They, or any adjacent character, can attempt to remove the javelin with a successful <strong>Hull</strong> save as a <strong>full action</strong>; otherwise, this effect lasts for the rest of the scene or until the Hornet takes this action again.",
+        "tags": [
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Hostile <strong>Impaired</strong> characters within the Hornet's <strong>Sensors</strong> recieve <strong>+2 Difficulty</strong> on all attacks, checks, and saves instead of <strong>+1 Difficulty</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_slingshot_hornet",
-    "name": "SLINGSHOT",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": false
-    },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Hornet makes a Tech Attack against a target in <strong>Sensors</strong>. On a success, they take <strong>{3/4/5} Heat</strong> and are pushed <strong>3 spaces</strong> in a direction of the Hornet's choice, then the Hornet moves to a free space within <strong>Range 5</strong> of the target as directly as possible.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 5
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_lock_hold_javelins_hornet",
-    "name": "LOCK/HOLD JAVELINS",
-    "origin": {
-      "type": "Class",
-      "name": "HORNET",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Hornet fires a javelin at a character within <strong>Range 5</strong> and line of sight. The target must succeed on a <strong>Hull</strong> save or be impaled, at which point the javelin tethers itself and its victim to the ground (or another surface), rendering them <strong>Immobilized</strong> and <strong>Shredded</strong>. They, or any adjacent character, can attempt to remove the javelin with a successful <strong>Hull</strong> save as a <strong>full action</strong>; otherwise, this effect lasts for the rest of the scene or until the Hornet takes this action again.",
-    "tags": [
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_raptor_plasma_rifle_operator",
-    "name": "RAPTOR PLASMA RIFLE",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_reliable",
-        "val": "{2/3/4}"
-      }
-    ],
-    "weapon_type": "Heavy Rifle",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Energy",
+    {
+        "id": "npc-rebake_npcf_raptor_plasma_rifle_operator",
+        "name": "Raptor Plasma Rifle",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_reliable",
+                "val": "{2/3/4}"
+            }
+        ],
+        "weapon_type": "Heavy Rifle",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          6,
-          8,
-          10
+            {
+                "type": "Energy",
+                "damage": [
+                    6,
+                    8,
+                    10
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 10
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_trace_drive_operator",
+        "name": "Trace Drive",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Operator <strong>teleports</strong> when they make their standard move. Whenever the Operator exceeds their <strong>Heat Cap</strong>, this system is disabled until the end of their next turn.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_strike_and_fade_operator",
+        "name": "Strike and Fade",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Whenever the Operator <strong>teleports</strong> during their turn before making any attacks, they gain <strong>+1 Accuracy</strong> on all attacks with the <strong>Raptor Plasma Rifle</strong> until the end of their turn. Whenever the Operator <strong>teleports</strong> during their turn after making any attacks, all attacks against them recieve <strong>+1 Difficulty</strong> until the end of their next turn.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_self_erasure_operator",
+        "name": "Self-Erasure",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When the Operator is destroyed, it immediately self-immolates in a wave of superheated plasma. All characters adjacent to the Operator when this takes place must succeed on an <strong>Agility</strong> save or take <strong>{4/6/8} Energy damage</strong> and rendered only able to draw line of sight to adjacent spaces until the end of their next. On a success, they take half damage only. This mech is then removed from the battlefield – it is utterly annihilated.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_telefrag_operator",
+        "name": "Telefrag",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Operator <strong>teleports</strong> into a space occupied by another character within line of sight and <strong>range 15</strong>. The target must succeed on an <strong>Agility</strong> save or take <strong>{4/5/6} AP Energy damage</strong> and become <strong>Jammed</strong> and <strong>Shredded</strong> until the end of their next turn. On a successful save, they take half damage only. Succeed or fail, the Operator takes <strong>1d6 AP Energy damage</strong> and then <strong>teleports</strong> to a new space within <strong>Range 5</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 6
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 10
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_trace_drive_operator",
-    "name": "TRACE DRIVE",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Operator <strong>teleports</strong> when they make their standard move. Whenever the Operator exceeds their <strong>Heat Cap</strong>, this system is disabled until the end of their next turn.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_strike_and_fade_operator",
-    "name": "STRIKE AND FADE",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_overload_shot_operator",
+        "name": "Overload Shot",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Operator makes an attack with the <strong>Raptor Plasma Rifle</strong>, treating its <strong>Range</strong> as <strong>Line 10</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Whenever the Operator <strong>teleports</strong> during their turn before making any attacks, they gain <strong>+1 Accuracy</strong> on all attacks with the <strong>Raptor Plasma Rifle</strong> until the end of their turn. Whenever the Operator <strong>teleports</strong> during their turn after making any attacks, all attacks against them recieve <strong>+1 Difficulty</strong> until the end of their next turn.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_self_erasure_operator",
-    "name": "SELF-ERASURE",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_fade_generator_operator",
+        "name": "Fade Generator",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Operator teleports to a space within <strong>Range 2</strong>. They may choose to teleport further taking <strong>1d6 Heat</strong> and adding that many additonal spaces to the movement.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "The Operator takes damage from a ranged or melee attack."
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When the Operator is destroyed, it immediately self-immolates in a wave of superheated plasma. All characters adjacent to the Operator when this takes place must succeed on an <strong>Agility</strong> save or take <strong>{4/6/8} Energy damage</strong> and rendered only able to draw line of sight to adjacent spaces until the end of their next. On a success, they take half damage only. This mech is then removed from the battlefield – it is utterly annihilated.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_telefrag_operator",
-    "name": "TELEFRAG",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_singularity_grenade_operator",
+        "name": "Singularity Grenade",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Operator may expend a charge to throw a grenade to a space within <strong>Range 5</strong>. Characters in the <strong>Blast 2</strong> energy pulse (excluding the Operator) must pass a <strong>Systems</strong> save or be <strong>teleported 2 spaces</strong> in a direction of the Operator's choice and treat the Operator as <strong>Invisible</strong> until the end of their next turn.<Br>The Operator then <strong>teleports</strong> their <strong>Speed</strong>.",
+        "tags": [
+            {
+                "id": "tg_grenade"
+            },
+            {
+                "id": "tg_limited",
+                "val": 1
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Operator <strong>teleports</strong> into a space occupied by another character within line of sight and <strong>range 15</strong>. The target must succeed on an <strong>Agility</strong> save or take <strong>{4/5/6} AP Energy damage</strong> and become <strong>Jammed</strong> and <strong>Shredded</strong> until the end of their next turn. On a successful save, they take half damage only. Succeed or fail, the Operator takes <strong>1d6 AP Energy damage</strong> and then <strong>teleports</strong> to a new space within <strong>Range 5</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 6
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_overload_shot_operator",
-    "name": "OVERLOAD SHOT",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_deniable_asset_operator",
+        "name": "Deniable Asset",
+        "origin": {
+            "type": "Class",
+            "name": "Operator [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Self Erasure now deals <strong>{6/8/10} damage</strong> (half on a successful save), and when the Operator is destroyed they may immediately <strong>teleport</strong> their <strong>Speed</strong> as a <strong>Reaction</strong> before self-immolating.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Operator makes an attack with the <strong>Raptor Plasma Rifle</strong>, treating its <strong>Range</strong> as <strong>Line 10</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_fade_generator_operator",
-    "name": "FADE GENERATOR",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": false
-    },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Operator teleports to a space within <strong>Range 2</strong>. They may choose to teleport further taking <strong>1d6 Heat</strong> and adding that many additonal spaces to the movement.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "The Operator takes damage from a ranged or melee attack."
-  },
-  {
-    "id": "npc-rebake_npcf_singularity_grenade_operator",
-    "name": "SINGULARITY GRENADE",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Operator may expend a charge to throw a grenade to a space within <strong>Range 5</strong>. Characters in the <strong>Blast 2</strong> energy pulse (excluding the Operator) must pass a <strong>Systems</strong> save or be <strong>teleported 2 spaces</strong> in a direction of the Operator's choice and treat the Operator as <strong>Invisible</strong> until the end of their next turn.<Br>The Operator then <strong>teleports</strong> their <strong>Speed</strong>.",
-    "tags": [
-      {
-        "id": "tg_grenade"
-      },
-      {
-        "id": "tg_limited",
-        "val": 1
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_deniable_asset_operator",
-    "name": "DENIABLE ASSET",
-    "origin": {
-      "type": "Class",
-      "name": "OPERATOR",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Self Erasure now deals <strong>{6/8/10} damage</strong> (half on a successful save), and when the Operator is destroyed they may immediately <strong>teleport</strong> their <strong>Speed</strong> as a <strong>Reaction</strong> before self-immolating.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_flamethrower_pyro",
-    "name": "FLAMETHROWER",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "This weapon deals <strong>double Burn</strong> to characters that already have any <strong>Burn</strong>.",
-    "tags": [
-      {
-        "id": "tg_heat_self",
-        "val": 4
-      }
-    ],
-    "weapon_type": "Heavy CQB",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "Burn",
+    {
+        "id": "npc-rebake_npcf_flamethrower_pyro",
+        "name": "Flamethrower",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "This weapon deals <strong>double Burn</strong> to characters that already have any <strong>Burn</strong>.",
+        "tags": [
+            {
+                "id": "tg_heat_self",
+                "val": 4
+            }
+        ],
+        "weapon_type": "Heavy CQB",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          3,
-          4,
-          5
+            {
+                "type": "Burn",
+                "damage": [
+                    3,
+                    4,
+                    5
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Cone",
+                "val": 5
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_firebreak_shield_pyro",
+        "name": "Firebreak Shield",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "At the end of the Pyro's turn, they create a <strong>Line 5</strong> wall of flame, <strong>4 spaces high</strong>, in free spaces within <strong>Range 3</strong> and line of sight. This wall doesn't block line of sight, but provides <strong>soft cover</strong>; when an attack is made against a character benefiting from this cover, roll <strong>1d6</strong>. On a <strong>4+</strong>, that attack misses. Characters can pass through this wall, but when crossing the wall for the first time in a round or starting their turn overlapping its spaces, they take <strong>{2/3/4} Burn</strong>. This wall lasts until the start of the Pyro's next turn, or until the Pyro moves or is <strong>Stunned</strong>, and its effect doesn't stack with <strong>Invisible</strong>.",
+        "tags": [
+            {
+                "id": "tg_shield"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Cone",
-        "val": 5
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_firebreak_shield_pyro",
-    "name": "FIREBREAK SHIELD",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "At the end of the Pyro's turn, they create a <strong>Line 5</strong> wall of flame, <strong>4 spaces high</strong>, in free spaces within <strong>Range 3</strong> and line of sight. This wall doesn't block line of sight, but provides <strong>soft cover</strong>; when an attack is made against a character benefiting from this cover, roll <strong>1d6</strong>. On a <strong>4+</strong>, that attack misses. Characters can pass through this wall, but when crossing the wall for the first time in a round or starting their turn overlapping its spaces, they take <strong>{2/3/4} Burn</strong>. This wall lasts until the start of the Pyro's next turn, or until the Pyro moves or is <strong>Stunned</strong>, and its effect doesn't stack with <strong>Invisible</strong>.",
-    "tags": [
-      {
-        "id": "tg_shield"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_explosive_vent_pyro",
-    "name": "EXPLOSIVE VENT",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_explosive_vent_pyro",
+        "name": "Explosive Vent",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Pyro clears all <strong>Heat</strong>. All characters within <strong>Burst 2</strong> must pass an <strong>Agility</strong> save or take <strong>Heat</strong> equal to <strong>half the amount the Pyro cleared</strong> and be knocked <strong>Prone</strong>.",
+        "tags": [
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Pyro clears all <strong>Heat</strong>. All characters within <strong>Burst 2</strong> must pass an <strong>Agility</strong> save or take <strong>Heat</strong> equal to <strong>half the amount the Pyro cleared</strong> and be knocked <strong>Prone</strong>.",
-    "tags": [
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_insulated_pyro",
-    "name": "INSULATED",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_insulated_pyro",
+        "name": "Insulated",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Pyro has <strong>Immunity</strong> to <strong>Burn</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Pyro has <strong>Immunity</strong> to <strong>Burn</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_napalm_bomb_pyro",
-    "name": "NAPALM BOMB",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_napalm_bomb_pyro",
+        "name": "Napalm Bomb",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Pyro launches a napalm canister that erupts in a <strong>Blast 1</strong> curtain of flame within Range 5. All characters within this area must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and <strong>{2/3/4} Heat</strong>. The Pyro may instead target a free area with this <strong>Blast</strong>; if they do, it creates a burning patch on the ground that lasts until this system is used again. Characters that start their turn at least partially within the area or move into it for the first time in a round must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and <strong>{2/3/4 Heat}</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": "5"
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Pyro launches a napalm canister that erupts in a <strong>Blast 1</strong> curtain of flame within Range 5. All characters within this area must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and <strong>{2/3/4} Heat</strong>. The Pyro may instead target a free area with this <strong>Blast</strong>; if they do, it creates a burning patch on the ground that lasts until this system is used again. Characters that start their turn at least partially within the area or move into it for the first time in a round must pass an <strong>Agility</strong> save or take <strong>{2/3/4} Burn</strong> and <strong>{2/3/4 Heat}</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": "5"
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_unshielded_reactor_pyro",
-    "name": "UNSHIELDED REACTOR",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_unshielded_reactor_pyro",
+        "name": "Unshielded Reactor",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Characters that start their turn within <strong>Range 3</strong> of the Pyro or who move into <strong>Range 3</strong> of them for the first time in a round take <strong>2/3/4 Heat</strong>, and they make all checks to clear <strong>Burn</strong> with <strong>+1 Difficulty</strong> as long as they remain within <strong>3 spaces</strong> of the Pyro.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Characters that start their turn within <strong>Range 3</strong> of the Pyro or who move into <strong>Range 3</strong> of them for the first time in a round take <strong>2/3/4 Heat</strong>, and they make all checks to clear <strong>Burn</strong> with <strong>+1 Difficulty</strong> as long as they remain within <strong>3 spaces</strong> of the Pyro.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_superhot_pyro",
-    "name": "SUPERHOT",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_superhot_pyro",
+        "name": "Superhot",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Pyro gains <strong>Resistance</strong> to all damage from the attack. The attacker must pass an <strong>Engineering</strong> save or take {3/4/5} <strong>Burn</strong>.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            },
+            {
+                "id": "tg_heat_self",
+                "val": "4"
+            }
+        ],
+        "trigger": "The Pyro takes damage from a melee attack."
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Pyro gains <strong>Resistance</strong> to all damage from the attack. The attacker must pass an <strong>Engineering</strong> save or take {3/4/5} <strong>Burn</strong>.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      },
-      {
-        "id": "tg_heat_self",
-        "val": "4"
-      }
-    ],
-    "trigger": "The Pyro takes damage from a melee attack."
-  },
-  {
-    "id": "npc-rebake_npcf_explosive_jet_pyro",
-    "name": "EXPLOSIVE JET",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_explosive_jet_pyro",
+        "name": "Explosive Jet",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "Hostile characters within <strong>Burst 2</strong> must pass a <strong>Hull</strong> save or be knocked back outside of the area and knocked <strong>Prone</strong>. The Pyro then flies <strong>5 spaces</strong> in any direction, but must land after completing that move. If the Pyro is in the <strong>Danger Zone</strong>, the <strong>Hull</strong> save is made with <strong>+1 Difficulty</strong> and this system's <strong>Recharge</strong> rolls automatically succeed.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "Hostile characters within <strong>Burst 2</strong> must pass a <strong>Hull</strong> save or be knocked back outside of the area and knocked <strong>Prone</strong>. The Pyro then flies <strong>5 spaces</strong> in any direction, but must land after completing that move. If the Pyro is in the <strong>Danger Zone</strong>, the <strong>Hull</strong> save is made with <strong>+1 Difficulty</strong> and this system's <strong>Recharge</strong> rolls automatically succeed.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_lingering_flames_pyro",
-    "name": "LINGERING FLAMES",
-    "origin": {
-      "type": "Class",
-      "name": "PYRO",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_lingering_flames_pyro",
+        "name": "Lingering Flames",
+        "origin": {
+            "type": "Class",
+            "name": "Pyro [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When the Pyro attacks with the <strong>Flamethrower</strong>, flames continue to Burn in <strong>3 free spaces</strong> of their choice within the affected area. When characters start their turn in one of these spaces or enter one for the first time in a round, they take <strong>{2/3/4} Burn</strong>. These spaces last until the end of the scene, or until the Pyro attacks with the <strong>Flamethrower</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When the Pyro attacks with the <strong>Flamethrower</strong>, flames continue to Burn in <strong>3 free spaces</strong> of their choice within the affected area. When characters start their turn in one of these spaces or enter one for the first time in a round, they take <strong>{2/3/4} Burn</strong>. These spaces last until the end of the scene, or until the Pyro attacks with the <strong>Flamethrower</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_carbon_fiber_sword_ronin",
-    "name": "CARBON FIBER SWORD",
-    "origin": {
-      "type": "Class",
-      "name": "RONIN",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "tags": [],
-    "weapon_type": "Main Melee",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ],
-    "damage": [
-      {
-        "type": "Kinetic",
+    {
+        "id": "npc-rebake_npcf_carbon_fiber_sword_ronin",
+        "name": "Carbon Fiber Sword",
+        "origin": {
+            "type": "Class",
+            "name": "Ronin [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "tags": [],
+        "weapon_type": "Main Melee",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ],
         "damage": [
-          6,
-          8,
-          10
+            {
+                "type": "Kinetic",
+                "damage": [
+                    6,
+                    8,
+                    10
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 2
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_rebound_ronin",
+        "name": "Rebound",
+        "origin": {
+            "type": "Class",
+            "name": "Ronin [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "They roll <strong>1d6</strong>: on <strong>4+</strong>, they gain <strong>Resistance</strong> to damage from that attack, and the attacker must repeat the attack against themselves. On <strong>3 or less</strong>, the Ronin may <strong>Boost</strong> towards the triggering attacker.",
+        "tags": [
+            {
+                "id": "tg_shield"
+            },
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "The Ronin takes damage from a ranged attack."
+    },
+    {
+        "id": "npc-rebake_npcf_counter-ballistic_suite_ronin",
+        "name": "Counter-Ballistic Suite",
+        "origin": {
+            "type": "Class",
+            "name": "Ronin [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Whenever a character makes a ranged attack against the Ronin, that character gains a <strong>Ronin's Mark</strong>. Only one character at a time can have a <strong>Ronin's Mark</strong>; if a new mark is applied, any others are removed. When the Ronin makes a successful attack against a character using the <strong>Carbon Fiber Sword</strong>, it can consume the <strong>Ronin's Mark</strong> to deal <strong>+1d6 bonus damage</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_chaff_launchers_ronin",
+        "name": "Chaff Launchers",
+        "origin": {
+            "type": "Class",
+            "name": "Ronin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Ranged attacks against the Ronin while <strong>Engaged</strong> receive <strong>+2 Difficulty</strong> instead of <strong>+1 Difficulty</strong>, and the Ronin gains <strong>soft cover</strong> until the start of their next turn whenever they <strong>Boost</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_instinct_mode_ronin",
+        "name": "Instinct Mode",
+        "origin": {
+            "type": "Class",
+            "name": "Ronin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Ronin enters a prepared stance, visible to everyone. Until the end of the Ronin’s next turn, the first time each turn that a hostile character in line of sight makes a ranged attack, as a <strong>reaction</strong> the Ronin may first <strong>Boost</strong> towards the triggering attacker and then make an attack against them with the <strong>Carbon Fiber Sword</strong> if they are within <strong>Range</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 2
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_rebound_ronin",
-    "name": "REBOUND",
-    "origin": {
-      "type": "Class",
-      "name": "RONIN",
-      "base": true
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "They roll <strong>1d6</strong>: on <strong>4+</strong>, they gain <strong>Resistance</strong> to damage from that attack, and the attacker must repeat the attack against themselves. On <strong>3 or less</strong>, the Ronin may <strong>Boost</strong> towards the triggering attacker.",
-    "tags": [
-      {
-        "id": "tg_shield"
-      },
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "The Ronin takes damage from a ranged attack."
-  },
-  {
-    "id": "npc-rebake_npcf_counter-ballistic_suite_ronin",
-    "name": "COUNTER-BALLISTIC SUITE",
-    "origin": {
-      "type": "Class",
-      "name": "RONIN",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_mag_field_ronin",
+        "name": "Mag Field",
+        "origin": {
+            "type": "Class",
+            "name": "Ronin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Whenever the Ronin takes damage or effects from missed attacks (e.g. <strong>Reliable</strong>), they may choose a different character within <strong>Range 5</strong> to also take the damage or effects.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Whenever a character makes a ranged attack against the Ronin, that character gains a <strong>Ronin's Mark</strong>. Only one character at a time can have a <strong>Ronin's Mark</strong>; if a new mark is applied, any others are removed. When the Ronin makes a successful attack against a character using the <strong>Carbon Fiber Sword</strong>, it can consume the <strong>Ronin's Mark</strong> to deal <strong>+1d6 bonus damage</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_chaff_launchers_ronin",
-    "name": "CHAFF LAUNCHERS",
-    "origin": {
-      "type": "Class",
-      "name": "RONIN",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_charged_slash_ronin",
+        "name": "Charged Slash",
+        "origin": {
+            "type": "Class",
+            "name": "Ronin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "An adjacent character must pass an <strong>Agility</strong> save or choose: become <strong>Jammed</strong> until the end of their next turn, or the Ronin chooses one of their equipped weapons and they take half that weapon's damage from a ruptured magazine or power cell, then they become <strong>Impaired</strong> until the end of their next turn. On a success, they become <strong>Impaired</strong> until the end of their next turn only.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Ranged attacks against the Ronin while <strong>Engaged</strong> receive <strong>+2 Difficulty</strong> instead of <strong>+1 Difficulty</strong>, and the Ronin gains <strong>soft cover</strong> until the start of their next turn whenever they <strong>Boost</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_instinct_mode_ronin",
-    "name": "INSTINCT MODE",
-    "origin": {
-      "type": "Class",
-      "name": "RONIN",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_extended_blade_ronin",
+        "name": "Extended Blade",
+        "origin": {
+            "type": "Class",
+            "name": "Ronin [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Ronin’s <strong>Carbon Fiber Sword</strong> becomes <strong>Threat 3</strong>. The first time each turn that the Ronin performs a critical hit with it, all characters of their choice within <strong>Threat</strong> take <strong>{2/3/4} Kinetic damage</strong>, excluding the target just attacked.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": " The Ronin enters a prepared stance, visible to everyone. Until the end of the Ronin’s next turn, the first time each turn that a hostile character in line of sight makes a ranged attack, as a <strong>reaction</strong> the Ronin may first <strong>Boost</strong> towards the triggering attacker and then make an attack against them with the <strong>Carbon Fiber Sword</strong> if they are within <strong>Range</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_mag_field_ronin",
-    "name": "MAG FIELD",
-    "origin": {
-      "type": "Class",
-      "name": "RONIN",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Whenever the Ronin takes damage or effects from missed attacks (e.g. <strong>Reliable</strong>), they may choose a different character within <strong>Range 5</strong> to also take the damage or effects.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_charged_slash_ronin",
-    "name": "CHARGED SLASH",
-    "origin": {
-      "type": "Class",
-      "name": "RONIN",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": " An adjacent character must pass an <strong>Agility</strong> save or choose: become <strong>Jammed</strong> until the end of their next turn, or the Ronin chooses one of their equipped weapons and they take half that weapon's damage from a ruptured magazine or power cell, then they become <strong>Impaired</strong> until the end of their next turn. On a success, they become <strong>Impaired</strong> until the end of their next turn only.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_extended_blade_ronin",
-    "name": "EXTENDED BLADE",
-    "origin": {
-      "type": "Class",
-      "name": "RONIN",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": " The Ronin’s <strong>Carbon Fiber Sword</strong> becomes <strong>Threat 3</strong>. The first time each turn that the Ronin performs a critical hit with it, all characters of their choice within <strong>Threat</strong> take <strong>{2/3/4} Kinetic damage</strong>, excluding the target just attacked.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_thermal_lance_scourer",
-    "name": "THERMAL LANCE",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_heat_self",
-        "val": 4
-      }
-    ],
-    "weapon_type": "Heavy Cannon",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ],
-    "damage": [
-      {
-        "type": "Energy",
+    {
+        "id": "npc-rebake_npcf_thermal_lance_scourer",
+        "name": "Thermal Lance",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_heat_self",
+                "val": 4
+            }
+        ],
+        "weapon_type": "Heavy Cannon",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ],
         "damage": [
-          6,
-          8,
-          10
+            {
+                "type": "Energy",
+                "damage": [
+                    6,
+                    8,
+                    10
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 8
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_focus_down_scourer",
+        "name": "Focus Down",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When the Scourer hits with the <strong>Thermal Lance</strong>, targets take <strong>{5/6/7} Burn</strong> if they were also successfully hit with the <strong>Thermal Lance</strong> in the previous round.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_cooling_module_scourer",
+        "name": "Cooling Module",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "At the start of their turn, the Scourer <strong>clears all Heat</strong> if they haven’t moved – including involuntary movement – since the end of their previous turn.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_ablative_shielding_scourer",
+        "name": "Ablative Shielding",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Scourer has <strong>Resistance</strong> to <strong>Energy damage</strong>.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_supercharged_scourer",
+        "name": "Supercharged",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Characters affected by <strong>Focus Down</strong> are also <strong>Shredded</strong> and <strong>Slowed</strong> until the end of their next turn.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_emergency_vent_scourer",
+        "name": "Emergency Vent",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "When the Scourer exceeds their <strong>Heat Cap</strong>, becomes <strong>Jammed</strong>, or becomes <strong>Stunned</strong>, they become <strong>Invisible</strong> until the start of their next turn.",
+        "tags": []
+    },
+    {
+        "id": "npc-rebake_npcf_pulse_laser_scourer",
+        "name": "Pulse Laser",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When the Scourer makes an attack with the <strong>Thermal Lance</strong>, they can attack two targets at a time, dealing half damage on hit. This trait automatically <strong>Recharges</strong> whenever <strong>Cooling Module</strong> activates.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 8
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_focus_down_scourer",
-    "name": "FOCUS DOWN",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": true
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When the Scourer hits with the <strong>Thermal Lance</strong>, targets take <strong>{5/6/7} Burn</strong> if they were also successfully hit with the <strong>Thermal Lance</strong> in the previous round.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_cooling_module_scourer",
-    "name": "COOLING MODULE",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_melt_scourer",
+        "name": "Melt",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Scourer makes a ranged attack against an object, deployable or <strong>Drone</strong> within <strong>Range 10</strong>, dealing <strong>20 AP Energy damage</strong> on a success. On hit, all characters within a <strong>Burst 2</strong> radius of the target are splashed with molten slag, and count as being successfully hit with the <strong>Thermal Lance</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "At the start of their turn, the Scourer <strong>clears all Heat</strong> if they haven’t moved – including involuntary movement – since the end of their previous turn.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_ablative_shielding_scourer",
-    "name": "ABLATIVE SHIELDING",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_thermal_overload_scourer",
+        "name": "Thermal Overload",
+        "origin": {
+            "type": "Class",
+            "name": "Scourer [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "If the <strong>Cooling Module</strong> does not activate at the start of the Scourer's turn, the <strong>Thermal Lance</strong> gains <strong>+4 Range</strong>, and on hit all other characters in a <strong>Burst 1</strong> area around the target take <strong>{3/4/5} Burn</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Scourer has <strong>Resistance</strong> to <strong>Energy damage</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_supercharged_scourer",
-    "name": "SUPERCHARGED",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_marker_rifle_scout",
+        "name": "Marker Rifle",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_smart"
+            }
+        ],
+        "weapon_type": "Main Rifle",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ],
+        "damage": [],
+        "range": [
+            {
+                "type": "Range",
+                "val": 15
+            }
+        ],
+        "on_hit": "Target receives <strong>Lock On</strong>, and they become <strong>Shredded</strong> until the end of their next turn."
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Characters affected by <strong>Focus Down</strong> are also <strong>Shredded</strong> and <strong>Slowed</strong> until the end of their next turn.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_emergency_vent_scourer",
-    "name": "EMERGENCY VENT",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_sight_scout",
+        "name": "Sight",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Scout ignores <strong>Hidden</strong> and <strong>Invisible</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "When the Scourer exceeds their <strong>Heat Cap</strong>, becomes <strong>Jammed</strong>, or becomes <strong>Stunned</strong>, they become <strong>Invisible</strong> until the start of their next turn.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_pulse_laser_scourer",
-    "name": "PULSE LASER",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_rebound_scan_scout",
+        "name": "Rebound Scan",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Scout makes a tech attack against a target in Sensors. On a success, the target and all hostile characters within <strong>Range 3</strong> of the target lose <strong>Hidden</strong> and <strong>Invisible</strong> and can't regain either status or benefit from any cover until the start of the Scout's next turn.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 4
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            2,
+            3,
+            4
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When the Scourer makes an attack with the <strong>Thermal Lance</strong>, they can attack two targets at a time, dealing half damage on hit. This trait automatically <strong>Recharges</strong> whenever <strong>Cooling Module</strong> activates.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_melt_scourer",
-    "name": "MELT",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_cloaking_field_scout",
+        "name": "Cloaking Field",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Scout generates a <strong>Burst 3</strong> cloaking field that lasts until the end of their next turn. The Scout and allied characters within the affected area are <strong>Invisible</strong>, but the Scout is <strong>Immobilized</strong> while it is active.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Scourer makes a ranged attack against an object, deployable or <strong>Drone</strong> within <strong>Range 10</strong>, dealing <strong>20 AP Energy damage</strong> on a success. On hit, all characters within a <strong>Burst 2</strong> radius of the target are splashed with molten slag, and count as being successfully hit with the <strong>Thermal Lance</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_thermal_overload_scourer",
-    "name": "THERMAL OVERLOAD",
-    "origin": {
-      "type": "Class",
-      "name": "SCOURER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_spotter_scout",
+        "name": "Spotter",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "While adjacent to the Scout, allied characters gain <strong>+1 Accuracy</strong> on all attack rolls.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "If the <strong>Cooling Module</strong> does not activate at the start of the Scourer's turn, the <strong>Thermal Lance</strong> gains <strong>+4 Range</strong>, and on hit all other characters in a <strong>Burst 1</strong> area around the target take <strong>{3/4/5} Burn</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_marker_rifle_scout",
-    "name": "MARKER RIFLE",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_scout_drone_scout",
+        "name": "Scout Drone",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "<strong>Scout Drone</strong> (<strong>Size</strong> 1/2, <strong>HP</strong> {5/8/10}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags</strong>: Drone)<br>The Scout deploys the drone to a free space within <strong>Sensors</strong> The drone creates a <strong>Burst 2</strong> perimeter, within which characters cannot become <strong>Invisible</strong> or <strong>Hide</strong>, and lose those conditions if they have them. The Scout and all allied characters also gain <strong>+1 Accuracy</strong> when attacking characters within the affected area. The drone can be deployed to a new location as a protocol.",
+        "tags": [
+            {
+                "id": "tg_drone"
+            },
+            {
+                "id": "tg_limited",
+                "val": 1
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_smart"
-      }
-    ],
-    "weapon_type": "Main Rifle",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ],
-    "damage": [],
-    "range": [
-      {
-        "type": "Range",
-        "val": 15
-      }
-    ],
-    "on_hit": "Target receives <strong>Lock On</strong>, and they become <strong>Shredded</strong> until the end of their next turn."
-  },
-  {
-    "id": "npc-rebake_npcf_sight_scout",
-    "name": "SIGHT",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_orbital_strike_scout",
+        "name": "Orbital Strike",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Scout chooses a space on the ground, within line of sight and <strong>Range 20</strong>; all characters know that it has been chosen. The Scout calls in an orbital bombardment that hits at the end of the next round, creating a <strong>Burst 2</strong> explosion. Characters in the affected area must make <strong>Agility</strong> saves. On a fail, they take <strong>{12/16/20} Energy damage</strong> and are knocked <strong>Prone</strong>. On a pass, they take half damage and remain standing.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Scout ignores <strong>Hidden</strong> and <strong>Invisible</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_rebound_scan_scout",
-    "name": "REBOUND SCAN",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_expose_weakness_scout",
+        "name": "Expose Weakness",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Characters that are successfully attacked with the <strong>Marker Rifle</strong> gain a <strong>Scout's Mark</strong>. Only one character can be marked this way at a time, and marking another character clears any marks from the last one. The next time an ally successfully hits a character with a <strong>Scout's Mark</strong>, they may consume the mark to choose one of the following:<ul><li>The Target takes <strong>+1d6 bonus damage</strong>.</li><li>The target is knocked <strong>Prone</strong>.</li><li>The target only has line of sight to adjacent spaces until the end of their next turn</li><ul>",
+        "tags": []
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Scout makes a tech attack against a target in Sensors. On a success, the target and all hostile characters within <strong>Range 3</strong> of the target lose <strong>Hidden</strong> and <strong>Invisible</strong> and can't regain either status or benefit from any cover until the start of the Scout's next turn.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 4
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      2,
-      3,
-      4
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_cloaking_field_scout",
-    "name": "CLOAKING FIELD",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_pathfinder_scout",
+        "name": "Pathfinder",
+        "origin": {
+            "type": "Class",
+            "name": "Scout [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "<strong>1/round</strong>, whenever the Scout successfully attacks with the <strong>Marker Rifle</strong>, an allied character within <strong>Sensors</strong> and line of sight can move up to their <strong>Speed</strong> as a Reaction.",
+        "tags": []
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Scout generates a <strong>Burst 3</strong> cloaking field that lasts until the end of their next turn. The Scout and allied characters within the affected area are <strong>Invisible</strong>, but the Scout is <strong>Immobilized</strong> while it is active.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_spotter_scout",
-    "name": "SPOTTER",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "While adjacent to the Scout, allied characters gain <strong>+1 Accuracy</strong> on all attack rolls.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_scout_drone_scout",
-    "name": "SCOUT DRONE",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": true
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "<strong>Scout Drone</strong> (<strong>Size</strong> 1/2, <strong>HP</strong> {5/8/10}, <strong>Evasion</strong> {10/10/10}, <strong>E-Defense</strong> {10/10/10}, <strong>Tags</strong>: Drone)<br>The Scout deploys the drone to a free space within <strong>Sensors</strong> The drone creates a <strong>Burst 2</strong> perimeter, within which characters cannot become <strong>Invisible</strong> or <strong>Hide</strong>, and lose those conditions if they have them. The Scout and all allied characters also gain <strong>+1 Accuracy</strong> when attacking characters within the affected area. The drone can be deployed to a new location as a protocol.",
-    "tags": [
-      {
-        "id": "tg_drone"
-      },
-      {
-        "id": "tg_limited",
-        "val": 1
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_orbital_strike_scout",
-    "name": "ORBITAL STRIKE",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": false
-    },
-    "locked": false,
-    "type": "System",
-    "effect": "The Scout chooses a space on the ground, within line of sight and <strong>Range 20</strong>; all characters know that it has been chosen. The Scout calls in an orbital bombardment that hits at the end of the next round, creating a <strong>Burst 2</strong> explosion. Characters in the affected area must make <strong>Agility</strong> saves. On a fail, they take <strong>{12/16/20} Energy damage</strong> and are knocked <strong>Prone</strong>. On a pass, they take half damage and remain standing.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_expose_weakness_scout",
-    "name": "EXPOSE WEAKNESS",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Characters that are successfully attacked with the <strong>Marker Rifle</strong> gain a <strong>Scout's Mark</strong>. Only one character can be marked this way at a time, and marking another character clears any marks from the last one. The next time an ally successfully hits a character with a <strong>Scout's Mark</strong>, they may consume the mark to choose one of the following:<ul><li>The Target takes <strong>+1d6 bonus damage</strong>.</li><li>The target is knocked <strong>Prone</strong>.</li><li>The target only has line of sight to adjacent spaces until the end of their next turn</li><ul>",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_pathfinder_scout",
-    "name": "PATHFINDER",
-    "origin": {
-      "type": "Class",
-      "name": "SCOUT",
-      "base": false
-    },
-    "locked": false,
-    "type": "Trait",
-    "effect": "<strong>1/round</strong>, whenever the Scout successfully attacks with the <strong>Marker Rifle</strong>, an allied character within <strong>Sensors</strong> and line of sight can move up to their <strong>Speed</strong> as a Reaction.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_grav_grenade_launcher_seeder",
-    "name": "GRAV-GRENADE LAUNCHER",
-    "origin": {
-      "type": "Class",
-      "name": "SEEDER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_arcing"
-      }
-    ],
-    "weapon_type": "Main Launcher",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "Explosive",
+    {
+        "id": "npc-rebake_npcf_grav_grenade_launcher_seeder",
+        "name": "Grav-Grenade Launcher",
+        "origin": {
+            "type": "Class",
+            "name": "Seeder [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_arcing"
+            }
+        ],
+        "weapon_type": "Main Launcher",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          2,
-          3,
-          4
+            {
+                "type": "Explosive",
+                "damage": [
+                    2,
+                    3,
+                    4
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 8
+            },
+            {
+                "type": "Blast",
+                "val": 1
+            }
+        ],
+        "on_hit": "Targets are pulled <strong>1 space</strong> in a direction of the Seeder's choice."
+    },
+    {
+        "id": "npc-rebake_npcf_lay_mines_seeder",
+        "name": "Lay Mines",
+        "origin": {
+            "type": "Class",
+            "name": "Seeder [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Seeder deploys one of the mines below in a free space within <strong>Range 3</strong>. Once deployed, the Seeder’s mines detonate when a hostile character moves adjacent to them, creating a <strong>Burst 1</strong> explosion that affects both allied and hostile characters.<ul><li><strong>Sealant Mine</strong>: Characters in the area must pass a <strong>Hull</strong> save or become <strong>Immobilized</strong> until the end of their next turn, then <strong>Slowed</strong> until the end of their subsequent turn.</li><li><strong>Explosive Mine</strong>: Characters in the area must pass an <strong>Agility</strong> save or take <strong>8/12/16 explosive damage</strong>. On a success, they take <strong>half damage</strong>.</li><li><strong>Shock Mine</strong>: Characters in the area must pass a <strong>Systems</strong> save or become <strong>Jammed</strong> until the end of their next turn, then <strong>Impaired</strong> until the end of their subsequent turn.</li><li><strong>Thermite Mine</strong>: Characters in the area must pass an <strong>Engineering</strong> save or take 4/5/6 Heat and have only line of sight to adjacent spaces until the end of their next turn. On a success, they take <strong>half Heat only</strong>.</li></ul><br>The Seeder may have up to <strong>three mines</strong> deployed at a time; if they deploy another mine, one of their currently deployed mines of their choice disarms and deactivates. When the Seeder is destroyed, its deployed mines remain active, but now detonate whenever any character moves adjacent to them.",
+        "tags": [
+            {
+                "id": "tg_mine"
+            },
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_turn",
+                "val": 1
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 8
-      },
-      {
-        "type": "Blast",
-        "val": 1
-      }
-    ],
-    "on_hit": "Targets are pulled <strong>1 space</strong> in a direction of the Seeder's choice."
-  },
-  {
-    "id": "npc-rebake_npcf_lay_mines_seeder",
-    "name": "LAY MINES",
-    "origin": {
-      "type": "Class",
-      "name": "SEEDER",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Seeder deploys one of the mines below in a free space within <strong>Range 3</strong>. Once deployed, the Seeder’s mines detonate when a hostile character moves adjacent to them, creating a <strong>Burst 1</strong> explosion that affects both allied and hostile characters.<ul><li><strong>Sealant Mine</strong>: Characters in the area must pass a <strong>Hull</strong> save or become <strong>Immobilized</strong> until the end of their next turn, then <strong>Slowed</strong> until the end of their subsequent turn.</li><li><strong>Explosive Mine</strong>: Characters in the area must pass an <strong>Agility</strong> save or take <strong>8/12/16 explosive damage</strong>. On a success, they take <strong>half damage</strong>.</li><li><strong>Shock Mine</strong>: Characters in the area must pass a <strong>Systems</strong> save or become <strong>Jammed</strong> until the end of their next turn, then <strong>Impaired</strong> until the end of their subsequent turn.</li><li><strong>Thermite Mine</strong>: Characters in the area must pass an <strong>Engineering</strong> save or take 4/5/6 Heat and have only line of sight to adjacent spaces until the end of their next turn. On a success, they take <strong>half Heat only</strong>.</li></ul><br>The Seeder may have up to <strong>three mines</strong> deployed at a time; if they deploy another mine, one of their currently deployed mines of their choice disarms and deactivates. When the Seeder is destroyed, its deployed mines remain active, but now detonate whenever any character moves adjacent to them.",
-    "tags": [
-      {
-        "id": "tg_mine"
-      },
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_turn",
-        "val": 1
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_safety_net_seeder",
-    "name": "SAFETY NET",
-    "origin": {
-      "type": "Class",
-      "name": "SEEDER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_safety_net_seeder",
+        "name": "Safety Net",
+        "origin": {
+            "type": "Class",
+            "name": "Seeder [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Seeder never triggers or sets off <strong>Mines</strong> or other proximity-based systems unless it chooses to do so.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Seeder never triggers or sets off <strong>Mines</strong> or other proximity-based systems unless it chooses to do so.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_grav_spike_seeder",
-    "name": "GRAV SPIKE",
-    "origin": {
-      "type": "Class",
-      "name": "SEEDER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_grav_spike_seeder",
+        "name": "Grav Spike",
+        "origin": {
+            "type": "Class",
+            "name": "Seeder [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "A character within line of sight and <strong>Range 5</strong> must succeed on a <strong>Systems</strong> save, or a grav spike attaches itself to them. The Seeder can detonate all grav spikes as a <strong>protocol</strong>, causing targets to automatically take <strong>4/5/6 AP explosive damage</strong> and be pulled <strong>3 spaces</strong> in a direction of their choice. Characters can remove a grav spike from themselves by passing a <strong>Systems</strong> save as a <strong>quick action</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "A character within line of sight and <strong>Range 5</strong> must succeed on a <strong>Systems</strong> save, or a grav spike attaches itself to them. The Seeder can detonate all grav spikes as a <strong>protocol</strong>, causing targets to automatically take <strong>4/5/6 AP explosive damage</strong> and be pulled <strong>3 spaces</strong> in a direction of their choice. Characters can remove a grav spike from themselves by passing a <strong>Systems</strong> save as a <strong>quick action</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_FASCAM_seeder",
-    "name": "FASCAM",
-    "origin": {
-      "type": "Class",
-      "name": "SEEDER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_FASCAM_seeder",
+        "name": "FASCAM",
+        "origin": {
+            "type": "Class",
+            "name": "Seeder [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Seeder launches a rocket which scatters a field of explosive micromines over a <strong>Blast 3</strong> area within <strong>Sensors</strong>; this area can overlap with obstructions (like cover or terrain) when deployed, but not characters. Characters who enter this area or attempt to move while within it for the first time in a round must pass a <strong>Systems</strong> save or step on a mine, taking <strong>5/6/7 explosive damage</strong>. Only one field of micromines can exist at a time, and if a new one is created, the previous one deactivates.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Seeder launches a rocket which scatters a field of explosive micromines over a <strong>Blast 3</strong> area within <strong>Sensors</strong>; this area can overlap with obstructions (like cover or terrain) when deployed, but not characters. Characters who enter this area or attempt to move while within it for the first time in a round must pass a <strong>Systems</strong> save or step on a mine, taking <strong>5/6/7 explosive damage</strong>. Only one field of micromines can exist at a time, and if a new one is created, the previous one deactivates.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_speed_deployer_seeder",
-    "name": "SPEED DEPLOYER",
-    "origin": {
-      "type": "Class",
-      "name": "SEEDER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_speed_deployer_seeder",
+        "name": "Speed Deployer",
+        "origin": {
+            "type": "Class",
+            "name": "Seeder [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "<strong>Lay Mines</strong> may now deploy up to <strong>three mines</strong> at a time instead of just one. If the Seeder deploys more than one mine at a time this way, this trait can't be used again until one of its mines detonates or is disarmed.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "<strong>Lay Mines</strong> may now deploy up to <strong>three mines</strong> at a time instead of just one. If the Seeder deploys more than one mine at a time this way, this trait can't be used again until one of its mines detonates or is disarmed.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_hopping_mines_seeder",
-    "name": "HOPPING MINES",
-    "origin": {
-      "type": "Class",
-      "name": "SEEDER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_hopping_mines_seeder",
+        "name": "Hopping Mines",
+        "origin": {
+            "type": "Class",
+            "name": "Seeder [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Mines deployed with <strong>Lay Mines</strong> also activate when hostile characters fly or move over or adjacent to them, up to <strong>10 spaces</strong> high. The mines jump up to <strong>10 spaces</strong>, detonating and affecting all characters within their area.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Mines deployed with <strong>Lay Mines</strong> also activate when hostile characters fly or move over or adjacent to them, up to <strong>10 spaces</strong> high. The mines jump up to <strong>10 spaces</strong>, detonating and affecting all characters within their area.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_last_line_seeder",
-    "name": "LAST LINE",
-    "origin": {
-      "type": "Class",
-      "name": "SEEDER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_last_line_seeder",
+        "name": "Last Line",
+        "origin": {
+            "type": "Class",
+            "name": "Seeder [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "Choose a mine that can be deployed with <strong>Lay Mines</strong>; the triggering character immediately detonates a hidden mine buried under the ground of that type. This Reaction may still be used even if the Seeder is destroyed.<br>If a hostile character is aware of this trait (i.e. via <strong>Scan</strong>, or automatically when the Seeder is destroyed), they may attempt a contested <strong>Systems</strong> check against the Seeder as a <strong>quick action</strong> while the Seeder (or its wreck) is within <strong>Sensors</strong>. If that character succeeds, this trait is disabled. This check automatically succeeds against destroyed Seeders.",
+        "tags": [
+            {
+                "id": "tg_reaction"
+            },
+            {
+                "id": "tg_limited",
+                "val": "1"
+            }
+        ],
+        "trigger": "A hostile character moves within <strong>Range 3</strong> of the Seeder."
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "Choose a mine that can be deployed with <strong>Lay Mines</strong>; the triggering character immediately detonates a hidden mine buried under the ground of that type. This Reaction may still be used even if the Seeder is destroyed.<br>If a hostile character is aware of this trait (i.e. via <strong>Scan</strong>, or automatically when the Seeder is destroyed), they may attempt a contested <strong>Systems</strong> check against the Seeder as a <strong>quick action</strong> while the Seeder (or its wreck) is within <strong>Sensors</strong>. If that character succeeds, this trait is disabled. This check automatically succeeds against destroyed Seeders.",
-    "tags": [
-      {
-        "id": "tg_reaction"
-      },
-      {
-        "id": "tg_limited",
-        "val": "1"
-      }
-    ],
-    "trigger": "A hostile character moves within <strong>Range 3</strong> of the Seeder."
-  },
-  {
-    "id": "npc-rebake_npcf_combat_shotgun_sentinel",
-    "name": "COMBAT SHOTGUN",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [
-      {
-        "id": "tg_reliable",
-        "val": "{2/3/4}"
-      }
-    ],
-    "weapon_type": "Main CQB",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_combat_shotgun_sentinel",
+        "name": "Combat Shotgun",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [
+            {
+                "id": "tg_reliable",
+                "val": "{2/3/4}"
+            }
+        ],
+        "weapon_type": "Main CQB",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ],
         "damage": [
-          6,
-          8,
-          10
-        ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 5
-      },
-      {
-        "type": "Threat",
-        "val": 3
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_retractable_sword_sentinel",
-    "name": "RETRACTABLE SWORD",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": true
+            {
+                "type": "kinetic",
+                "damage": [
+                    6,
+                    8,
+                    10
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 5
+            },
+            {
+                "type": "Threat",
+                "val": 3
+            }
+        ],
+        "on_hit": ""
     },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "",
-    "tags": [],
-    "weapon_type": "Main Melee",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_retractable_sword_sentinel",
+        "name": "Retractable Sword",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "",
+        "tags": [],
+        "weapon_type": "Main Melee",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          4,
-          5,
-          6
+            {
+                "type": "kinetic",
+                "damage": [
+                    4,
+                    5,
+                    6
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 1
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_eye_of_midnight_sentinel",
+        "name": "Eye of Midnight",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Sentinel becomes <strong>Slowed</strong>, but can take the <strong>Overwatch</strong> Reaction <strong>1/turn</strong> instead of <strong>1/round</strong>. Additionally, they may attack with <strong>Overwatch</strong> using the <strong>Combat Shotgun</strong> when hostile characters enter, leave, or exit spaces within their <strong>Threat</strong> no matter whether they started their movement there. Once activated, this effect lasts until it is deactivated as a <strong>quick action</strong>.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 1
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_eye_of_midnight_sentinel",
-    "name": "EYE OF MIDNIGHT",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Sentinel becomes <strong>Slowed</strong>, but can take the <strong>Overwatch</strong> Reaction <strong>1/turn</strong> instead of <strong>1/round</strong>. Additionally, they may attack with <strong>Overwatch</strong> using the <strong>Combat Shotgun</strong> when hostile characters enter, leave, or exit spaces within their <strong>Threat</strong> no matter whether they started their movement there. Once activated, this effect lasts until it is deactivated as a <strong>quick action</strong>.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_guardian_sentinel",
-    "name": "GUARDIAN",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_guardian_sentinel",
+        "name": "Guardian",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Allied characters can use the Sentinel for <strong>hard cover</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Allied characters can use the Sentinel for <strong>hard cover</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_punisher_ammunition_sentinel",
-    "name": "PUNISHER AMMUNITION",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_punisher_ammunition_sentinel",
+        "name": "Punisher Ammunition",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Characters damaged by the Sentinel’s <strong>Overwatch</strong> attacks also become <strong>Slowed</strong> until the end of their next turn.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Characters damaged by the Sentinel’s <strong>Overwatch</strong> attacks also become <strong>Slowed</strong> until the end of their next turn.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_bodyguard_sentinel",
-    "name": "BODYGUARD",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_bodyguard_sentinel",
+        "name": "Bodyguard",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Sentinel chooses an allied character within <strong>Range 5</strong> as their ward and gains the <strong>Reflexive Blow</strong> Reaction, which can be taken as many times per round as it is triggered",
+        "tags": [
+            {
+                "id": "tg_protocol"
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": ""
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Sentinel chooses an allied character within <strong>Range 5</strong> as their ward and gains the <strong>Reflexive Blow</strong> Reaction, which can be taken as many times per round as it is triggered",
-    "tags": [
-      {
-        "id": "tg_protocol"
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": ""
-  },
-  {
-    "id": "npc-rebake_npcf_reflexive_blow_sentinel",
-    "name": "REFLEXIVE BLOW",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_reflexive_blow_sentinel",
+        "name": "Reflexive Blow",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Sentinel may move their <strong>Speed</strong> towards their ward by the most direct route possible, then attack the inciting character with <strong>Overwatch</strong>. This Reaction interrupts and resolves before the triggering action, ignores engagement, and doesn’t provoke reactions.",
+        "tags": [
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "Someone attacks the Sentinel’s ward."
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Sentinel may move their <strong>Speed</strong> towards their ward by the most direct route possible, then attack the inciting character with <strong>Overwatch</strong>. This Reaction interrupts and resolves before the triggering action, ignores engagement, and doesn’t provoke reactions.",
-    "tags": [
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "Someone attacks the Sentinel’s ward."
-  },
-  {
-    "id": "npc-rebake_npcf_wrath_lock_sentinel",
-    "name": "WRATH-LOCK",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_wrath_lock_sentinel",
+        "name": "Wrath-Lock",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Sentinel may <strong>Boost</strong> towards the triggering character, and the triggering character gains <strong>Lock On</strong>.",
+        "tags": [
+            {
+                "id": "tg_reaction"
+            },
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ],
+        "trigger": "A hostile character in line of sight moves."
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Sentinel may <strong>Boost</strong> towards the triggering character, and the triggering character gains <strong>Lock On</strong>.",
-    "tags": [
-      {
-        "id": "tg_reaction"
-      },
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ],
-    "trigger": "A hostile character in line of sight moves."
-  },
-  {
-    "id": "npc-rebake_npcf_impaler_sentinel",
-    "name": "IMPALER",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_impaler_sentinel",
+        "name": "Impaler",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "When the Sentinel hits with <strong>Overwatch</strong>, their target must pass a <strong>Hull</strong> save or become <strong>Immobilized</strong> and <strong>Jammed</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "When the Sentinel hits with <strong>Overwatch</strong>, their target must pass a <strong>Hull</strong> save or become <strong>Immobilized</strong> and <strong>Jammed</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_marker_shells_sentinel",
-    "name": "MARKER SHELLS",
-    "origin": {
-      "type": "Class",
-      "name": "SENTINEL",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_marker_shells_sentinel",
+        "name": "Marker Shells",
+        "origin": {
+            "type": "Class",
+            "name": "Sentinel [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Characters damaged by the Sentinel's <strong>Combat Shotgun</strong> (including <strong>Reliable</strong> damage) gain a <strong>Sentinel's Mark</strong>. Whenever the Sentinel makes an <strong>Overwatch</strong> attack against a marked character, they gain <strong>+1 Accuracy</strong> and ignore <strong>Invisible</strong>. All <strong>Sentinel's Marks</strong> are cleared at the start of the Sentinel's turn.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Characters damaged by the Sentinel's <strong>Combat Shotgun</strong> (including <strong>Reliable</strong> damage) gain a <strong>Sentinel's Mark</strong>. Whenever the Sentinel makes an <strong>Overwatch</strong> attack against a marked character, they gain <strong>+1 Accuracy</strong> and ignore <strong>Invisible</strong>. All <strong>Sentinel's Marks</strong> are cleared at the start of the Sentinel's turn.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_anti_materiel_rifle_sniper",
-    "name": "ANTI-MATERIEL RIFLE",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "This weapon does not gain <strong>Accuracy</strong> from attacking <strong>Prone</strong> targets",
-    "tags": [
-      {
-        "id": "tg_ap"
-      },
-      {
-        "id": "tg_ordnance"
-      },
-      {
-        "id": "tg_loading"
-      }
-    ],
-    "weapon_type": "Superheavy Rifle",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_anti_materiel_rifle_sniper",
+        "name": "Anti-Materiel Rifle",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "This weapon does not gain <strong>Accuracy</strong> from attacking <strong>Prone</strong> targets",
+        "tags": [
+            {
+                "id": "tg_ap"
+            },
+            {
+                "id": "tg_ordnance"
+            },
+            {
+                "id": "tg_loading"
+            }
+        ],
+        "weapon_type": "Superheavy Rifle",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          10,
-          15,
-          20
+            {
+                "type": "kinetic",
+                "damage": [
+                    10,
+                    15,
+                    20
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 20
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_snipers_mark_sniper",
+        "name": "Sniper’s Mark",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "A character within <strong>Range 20</strong> and line of sight gains the <strong>Sniper’s Mark</strong>. Against targets with the <strong>Sniper’s Mark</strong>, the sniper gains <strong>+1 Accuracy</strong> on attacks with the <strong>Anti-Materiel Rifle</strong> and may choose to deal <strong>1 structure damage</strong> instead of its usual damage on hit.<br>Characters know when they have the <strong>Sniper's Mark</strong> They ignore its effects if they are in cover or <strong>Prone</strong>. On their turn, characters with the <strong>Sniper's Mark</strong> may drop <strong>Prone</strong> as a <strong>free action</strong><br>The Sniper can only mark one character at a time, but can transfer the <strong>Sniper's Mark</strong> to another character within <strong>Range 20</strong> and line of sight as a <strong>full action</strong>, or whenever the sniper reloads the <strong>Anti-Material Rifle</strong>.",
+        "tags": [
+            {
+                "id": "tg_full_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 20
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_snipers_mark_sniper",
-    "name": "SNIPER’S MARK",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "A character within <strong>Range 20</strong> and line of sight gains the <strong>Sniper’s Mark</strong>. Against targets with the <strong>Sniper’s Mark</strong>, the sniper gains <strong>+1 Accuracy</strong> on attacks with the <strong>Anti-Materiel Rifle</strong> and may choose to deal <strong>1 structure damage</strong> instead of its usual damage on hit.<br>Characters know when they have the <strong>Sniper's Mark</strong> They ignore its effects if they are in cover or <strong>Prone</strong>. On their turn, characters with the <strong>Sniper's Mark</strong> may drop <strong>Prone</strong> as a <strong>free action</strong><br>The Sniper can only mark one character at a time, but can transfer the <strong>Sniper's Mark</strong> to another character within <strong>Range 20</strong> and line of sight as a <strong>full action</strong>, or whenever the sniper reloads the <strong>Anti-Material Rifle</strong>.",
-    "tags": [
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_climber_sniper",
-    "name": "CLIMBER",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_climber_sniper",
+        "name": "Climber",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Sniper treats all solid surfaces as flat ground for the purposes of movement; they can move and remain stationary on any surface without penalty, including overhanging and vertical surfaces, although they begin to fall if knocked <strong>Prone</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Sniper treats all solid surfaces as flat ground for the purposes of movement; they can move and remain stationary on any surface without penalty, including overhanging and vertical surfaces, although they begin to fall if knocked <strong>Prone</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_sharpshooter_sniper",
-    "name": "SHARPSHOOTER",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_sharpshooter_sniper",
+        "name": "Sharpshooter",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Sniper can attempt a called shot before attacking characters with the <strong>Sniper's Mark</strong> using the <strong>Anti-Materiel Rifle</strong>. This attack functions as usual, with an additional effect on a successful attack.<br>The Sniper may choose from the following:<ul><li><strong>Target Head:</strong> Targets must pass a <strong>Hull</strong> save or only be able to draw line of sight to adjacent spaces until the end of their next turn.</li><li><strong>Target Legs:</strong> Targets must pass an <strong>Agility</strong> save or be <strong>Immobilized</strong> until the end of their next turn.</li><li><strong>Target Hardpoints</strong>: Targets must pass a <strong>Systems</strong> save or become <strong>Jammed</strong> until the end of their next turn.</li><li><strong>Target Body:</strong> Targets must pass an <strong>Engineering</strong> save or become <strong>Shredded</strong> until the end of their next turn.</li></ul>",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Sniper can attempt a called shot before attacking characters with the <strong>Sniper's Mark</strong> using the <strong>Anti-Materiel Rifle</strong>. This attack functions as usual, with an additional effect on a successful attack.<br>The Sniper may choose from the following:<ul><li><strong>Target Head:</strong> Targets must pass a <strong>Hull</strong> save or only be able to draw line of sight to adjacent spaces until the end of their next turn.</li><li><strong>Target Legs:</strong> Targets must pass an <strong>Agility</strong> save or be <strong>Immobilized</strong> until the end of their next turn.</li><li><strong>Target Hardpoints</strong>: Targets must pass a <strong>Systems</strong> save or become <strong>Jammed</strong> until the end of their next turn.</li><li><strong>Target Body:</strong> Targets must pass an <strong>Engineering</strong> save or become <strong>Shredded</strong> until the end of their next turn.</li></ul>",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_shift_sights_sniper",
-    "name": "SHIFT SIGHTS",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_shift_sights_sniper",
+        "name": "Shift Sights",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Sniper may transfer the <strong>Sniper's Mark</strong> to a character within <strong>Range 2</strong> of the currently marked character.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_protocol"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Sniper may transfer the <strong>Sniper's Mark</strong> to a character within <strong>Range 2</strong> of the currently marked character.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_protocol"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_defensive_grapple_sniper",
-    "name": "DEFENSIVE GRAPPLE",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_defensive_grapple_sniper",
+        "name": "Defensive Grapple",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Sniper uses a grappling hook to <strong>fly</strong> to any free space that ends on an object or surface within <strong>Range 5</strong>, including vertical and overhanging surfaces. The Sniper also gains the <strong>Relocation</strong> reaction.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 4
+            },
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": ""
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Sniper uses a grappling hook to <strong>fly</strong> to any free space that ends on an object or surface within <strong>Range 5</strong>, including vertical and overhanging surfaces. The Sniper also gains the <strong>Relocation</strong> reaction.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 4
-      },
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": ""
-  },
-  {
-    "id": "npc-rebake_npcf_relocation_sniper",
-    "name": "RELOCATION",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_relocation_sniper",
+        "name": "Relocation",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Sniper uses Defensive Grapple.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "An hostile character in line of sight moves."
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Sniper uses Defensive Grapple.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "An hostile character in line of sight moves."
-  },
-  {
-    "id": "npc-rebake_npcf_moving_target_sniper",
-    "name": "MOVING TARGET",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_moving_target_sniper",
+        "name": "Moving Target",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Reaction",
+        "effect": "The Sniper interrupts the movement. The character must immediately stop, give up all remaining movement, and fall <strong>Prone</strong> or they gain the <strong>Sniper's Mark.</strong> <br>If they already have the <strong>Sniper's Mark</strong>, the Sniper instead may make an immediate attack against them with the <strong>Anti-Materiel Rifle</strong>.",
+        "tags": [
+            {
+                "id": "tg_round",
+                "val": 1
+            },
+            {
+                "id": "tg_reaction"
+            }
+        ],
+        "trigger": "A hostile character in line of sight and <strong>Range 20</strong> moves."
     },
-    "locked": false,
-    "type": "Reaction",
-    "effect": "The Sniper interrupts the movement. The character must immediately stop, give up all remaining movement, and fall <strong>Prone</strong> or they gain the <strong>Sniper's Mark.</strong> <br>If they already have the <strong>Sniper's Mark</strong>, the Sniper instead may make an immediate attack against them with the <strong>Anti-Materiel Rifle</strong>.",
-    "tags": [
-      {
-        "id": "tg_round",
-        "val": 1
-      },
-      {
-        "id": "tg_reaction"
-      }
-    ],
-    "trigger": "A hostile character in line of sight and <strong>Range 20</strong> moves."
-  },
-  {
-    "id": "npc-rebake_npcf_deadeye_sniper",
-    "name": "DEADEYE",
-    "origin": {
-      "type": "Class",
-      "name": "SNIPER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_deadeye_sniper",
+        "name": "Deadeye",
+        "origin": {
+            "type": "Class",
+            "name": "Sniper [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Sniper gets <strong>+1 Accuracy</strong> on attacks with the <strong>Anti-Materiel Rifle</strong> against characters that did not move their <strong>Speed</strong> or more during their turns.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Sniper gets <strong>+1 Accuracy</strong> on attacks with the <strong>Anti-Materiel Rifle</strong> against characters that did not move their <strong>Speed</strong> or more during their turns.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_monowire_sword_specter",
-    "name": "MONOWIRE SWORD",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": true
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "<strong>Armor</strong> is doubled against this weapon.",
-    "tags": [],
-    "weapon_type": "Main Melee",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_monowire_sword_specter",
+        "name": "Monowire Sword",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "<strong>Armor</strong> is doubled against this weapon.",
+        "tags": [],
+        "weapon_type": "Main Melee",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          5,
-          6,
-          7
+            {
+                "type": "kinetic",
+                "damage": [
+                    5,
+                    6,
+                    7
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Threat",
+                "val": 2
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_prowl_specter",
+        "name": "Prowl",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Specter moves spaces equal to <strong>Speed</strong>, then becomes <strong>Hidden</strong>. This movement ignores engagement and doesn’t provoke reactions.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Threat",
-        "val": 2
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_prowl_specter",
-    "name": "PROWL",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Specter moves spaces equal to <strong>Speed</strong>, then becomes <strong>Hidden</strong>. This movement ignores engagement and doesn’t provoke reactions.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_tactical_cloak_specter",
-    "name": "TACTICAL CLOAK",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_tactical_cloak_specter",
+        "name": "Tactical Cloak",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Specter is permanently <strong>Invisible</strong>. As a <strong>Full Action</strong>, a character can engage in a contested <strong>Systems</strong> check with the Specter to attempt to disable their cloak; all characters are aware of this. The Specter must be within their Sensors for them to attempt this check. If they succeed, the Specter takes <strong>4 Heat</strong> and this trait is disabled until the end of their next turn. If they fail, that character gains <strong>Lock On</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Specter is permanently <strong>Invisible</strong>. As a <strong>Full Action</strong>, a character can engage in a contested <strong>Systems</strong> check with the Specter to attempt to disable their cloak; all characters are aware of this. The Specter must be within their Sensors for them to attempt this check. If they succeed, the Specter takes <strong>4 Heat</strong> and this trait is disabled until the end of their next turn. If they fail, that character gains <strong>Lock On</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_hunt_specter",
-    "name": "HUNT",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_hunt_specter",
+        "name": "Hunt",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The <strong>Monowire Sword</strong> deals double damage when no other characters are adjacent to the target.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The <strong>Monowire Sword</strong> deals double damage when no other characters are adjacent to the target.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_step_specter",
-    "name": "STEP",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_step_specter",
+        "name": "Step",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Specter <strong>teleports</strong> to a free space within line of sight and <strong>Range 50</strong>.",
+        "tags": [
+            {
+                "id": "tg_recharge",
+                "val": 5
+            },
+            {
+                "id": "tg_quick_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Specter <strong>teleports</strong> to a free space within line of sight and <strong>Range 50</strong>.",
-    "tags": [
-      {
-        "id": "tg_recharge",
-        "val": 5
-      },
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_drain_systems_specter",
-    "name": "DRAIN SYSTEMS",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_drain_systems_specter",
+        "name": "Drain Systems",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Specter makes a tech attack against an adjacent character. On a success, the target becomes <strong>Stunned</strong>. This effect lasts until a character other than the Specter starts their turn adjacent to the target or moves adjacent to the target.",
+        "tags": [
+            {
+                "id": "tg_full_tech"
+            }
+        ],
+        "tech_type": "Full",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Specter makes a tech attack against an adjacent character. On a success, the target becomes <strong>Stunned</strong>. This effect lasts until a character other than the Specter starts their turn adjacent to the target or moves adjacent to the target.",
-    "tags": [
-      {
-        "id": "tg_full_tech"
-      }
-    ],
-    "tech_type": "Full",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_lure_specter",
-    "name": "LURE",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_lure_specter",
+        "name": "Lure",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Specter makes a tech attack against a character within <strong>Sensors</strong>. On a success, that character must choose: move their <strong>Speed</strong> towards the Specter, or become <strong>Slowed</strong> and <strong>Impaired</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 4
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            1,
+            2,
+            3
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Specter makes a tech attack against a character within <strong>Sensors</strong>. On a success, that character must choose: move their <strong>Speed</strong> towards the Specter, or become <strong>Slowed</strong> and <strong>Impaired</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 4
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      1,
-      2,
-      3
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_ghostwalk_specter",
-    "name": "GHOSTWALK",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_ghostwalk_specter",
+        "name": "Ghostwalk",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Specter becomes <strong>Intangible</strong> until the start of their next turn and moves spaces equal to their <strong>Speed</strong>. At the start of their next turn, their next attack with the <strong>Monowire Sword</strong> gains <strong>+1 Accuracy</strong> and deals <strong>+1d6 bonus damage</strong> on a critical hit. This bonus damage is not doubled.",
+        "tags": [
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Specter becomes <strong>Intangible</strong> until the start of their next turn and moves spaces equal to their <strong>Speed</strong>. At the start of their next turn, their next attack with the <strong>Monowire Sword</strong> gains <strong>+1 Accuracy</strong> and deals <strong>+1d6 bonus damage</strong> on a critical hit. This bonus damage is not doubled.",
-    "tags": [
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_machine_pistol_specter",
-    "name": "MACHINE PISTOL",
-    "origin": {
-      "type": "Class",
-      "name": "SPECTER",
-      "base": false
-    },
-    "locked": false,
-    "type": "Weapon",
-    "effect": "The Specter can move <strong>2 spaces</strong> in any direction before or after attacking with this weapon. This movement ignores engagement and doesn't provoke reactions.",
-    "tags": [],
-    "weapon_type": "Auxiliary CQB",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "damage": [
-      {
-        "type": "kinetic",
+    {
+        "id": "npc-rebake_npcf_machine_pistol_specter",
+        "name": "Machine Pistol",
+        "origin": {
+            "type": "Class",
+            "name": "Specter [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Weapon",
+        "effect": "The Specter can move <strong>2 spaces</strong> in any direction before or after attacking with this weapon. This movement ignores engagement and doesn't provoke reactions.",
+        "tags": [],
+        "weapon_type": "Auxiliary CQB",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
         "damage": [
-          3,
-          4,
-          5
+            {
+                "type": "kinetic",
+                "damage": [
+                    3,
+                    4,
+                    5
+                ]
+            }
+        ],
+        "range": [
+            {
+                "type": "Range",
+                "val": 5
+            },
+            {
+                "type": "Threat",
+                "val": 3
+            }
+        ],
+        "on_hit": ""
+    },
+    {
+        "id": "npc-rebake_npcf_sealant_gun_support",
+        "name": "Sealant Gun",
+        "origin": {
+            "type": "Class",
+            "name": "Support [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Support chooses a character within line of sight and <strong>Range 5</strong>, allied or hostile:<ul><li><strong>Allied:</strong> The target clears all <strong>Burn</strong>, but becomes <strong>Slowed</strong> until the end of their next turn.</li><li><strong>Hostile:</strong> The target must pass an <strong>Agility</strong> save or become <strong>Slowed</strong> until the end of their next turn. Succeed of fail, a <strong>Burst 1</strong> area around them becomes <strong>difficult terrain</strong> for the rest of the scene.</li></ul>",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            }
         ]
-      }
-    ],
-    "range": [
-      {
-        "type": "Range",
-        "val": 5
-      },
-      {
-        "type": "Threat",
-        "val": 3
-      }
-    ],
-    "on_hit": ""
-  },
-  {
-    "id": "npc-rebake_npcf_sealant_gun_support",
-    "name": "SEALANT GUN",
-    "origin": {
-      "type": "Class",
-      "name": "SUPPORT",
-      "base": true
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Support chooses a character within line of sight and <strong>Range 5</strong>, allied or hostile:<ul><li><strong>Allied:</strong> The target clears all <strong>Burn</strong>, but becomes <strong>Slowed</strong> until the end of their next turn.</li><li><strong>Hostile:</strong> The target must pass an <strong>Agility</strong> save or become <strong>Slowed</strong> until the end of their next turn. Succeed of fail, a <strong>Burst 1</strong> area around them becomes <strong>difficult terrain</strong> for the rest of the scene.</li></ul>",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_restock_drone_support",
-    "name": "RESTOCK DRONE",
-    "origin": {
-      "type": "Class",
-      "name": "SUPPORT",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_restock_drone_support",
+        "name": "Restock Drone",
+        "origin": {
+            "type": "Class",
+            "name": "Support [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "Restock Drone (Size 1/2, HP {5/8/10}, Evasion {10/10/10}, E-Defense {10/10/10}, Tags: Drone)<br>This drone can be deployed hovering in a space within <strong>Range 5</strong>. The next time an allied character moves through or next to the drone, it clamps on and discharges its reserves, letting them either regain {5/8/10} <strong>HP</strong> or reload one <strong>Loading</strong> weapon.",
+        "tags": [
+            {
+                "id": "tg_drone"
+            },
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 5
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "Restock Drone (Size 1/2, HP {5/8/10}, Evasion {10/10/10}, E-Defense {10/10/10}, Tags: Drone)<br>This drone can be deployed hovering in a space within <strong>Range 5</strong>. The next time an allied character moves through or next to the drone, it clamps on and discharges its reserves, letting them either regain {5/8/10} <strong>HP</strong> or reload one <strong>Loading</strong> weapon.",
-    "tags": [
-      {
-        "id": "tg_drone"
-      },
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 5
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_nano-repair_cloud_support",
-    "name": "NANO-REPAIR CLOUD",
-    "origin": {
-      "type": "Class",
-      "name": "SUPPORT",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_nano-repair_cloud_support",
+        "name": "Nano-Repair Cloud",
+        "origin": {
+            "type": "Class",
+            "name": "Support [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "While they are adjacent to the Support, allied characters roll twice on all saves and mech skill checks and choose the higher result.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "While they are adjacent to the Support, allied characters roll twice on all saves and mech skill checks and choose the higher result.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_desant_hardpoints_support",
-    "name": "DESANT HARDPOINTS",
-    "origin": {
-      "type": "Class",
-      "name": "SUPPORT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_desant_hardpoints_support",
+        "name": "Desant Hardpoints",
+        "origin": {
+            "type": "Class",
+            "name": "Support [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Adjacent, non-<strong>Immobilized</strong> allied characters can climb onto the Support as a <strong>quick action.</strong> While riding, they occupy the same space, move when the Support moves (even if they're <strong>Slowed</strong>), and benefit from <strong>soft cover.</strong> If they or the Support are knocked <strong>Prone</strong>, <strong>Stunned</strong>, <strong>Immobilized</strong>, or destroyed, they land <strong>Prone</strong> in adjacent spaces. Riders can climb down as part of any movement away.<br>The Support can carry one <strong>Squad</strong> or characters whose own combined <strong>Size</strong> is less than its own.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Adjacent, non-<strong>Immobilized</strong> allied characters can climb onto the Support as a <strong>quick action.</strong> While riding, they occupy the same space, move when the Support moves (even if they're <strong>Slowed</strong>), and benefit from <strong>soft cover.</strong> If they or the Support are knocked <strong>Prone</strong>, <strong>Stunned</strong>, <strong>Immobilized</strong>, or destroyed, they land <strong>Prone</strong> in adjacent spaces. Riders can climb down as part of any movement away.<br>The Support can carry one <strong>Squad</strong> or characters whose own combined <strong>Size</strong> is less than its own.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_remote_cloud_support",
-    "name": "REMOTE CLOUD",
-    "origin": {
-      "type": "Class",
-      "name": "SUPPORT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_remote_cloud_support",
+        "name": "Remote Cloud",
+        "origin": {
+            "type": "Class",
+            "name": "Support [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "The Support releases a <strong>Blast 2</strong> nanite cloud within <strong>Range 5</strong>. Allied characters within this area gain <strong>+1 Accuracy</strong> on all checks and saves. This effect does not stack with other <strong>Remote Clouds</strong>. The cloud lasts until the end of the scene, until the Support is destroyed, or until the Support uses this system again.",
+        "tags": [
+            {
+                "id": "tg_quick_action"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 5
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "The Support releases a <strong>Blast 2</strong> nanite cloud within <strong>Range 5</strong>. Allied characters within this area gain <strong>+1 Accuracy</strong> on all checks and saves. This effect does not stack with other <strong>Remote Clouds</strong>. The cloud lasts until the end of the scene, until the Support is destroyed, or until the Support uses this system again.",
-    "tags": [
-      {
-        "id": "tg_quick_action"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 5
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_remote_reboot_support",
-    "name": "REMOTE REBOOT",
-    "origin": {
-      "type": "Class",
-      "name": "SUPPORT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_remote_reboot_support",
+        "name": "Remote Reboot",
+        "origin": {
+            "type": "Class",
+            "name": "Support [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Support clears any two of the following <strong>conditions</strong> currently affecting an allied character in <strong>Range 5</strong>: <strong>Impaired</strong>, <strong>Jammed</strong>, <strong>Stunned</strong>, <strong>Slowed</strong>. That character may then either move up to their <strong>Speed</strong> or stand from <strong>Prone</strong>.",
+        "tags": [
+            {
+                "id": "tg_full_action"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 6
+            }
+        ]
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Support clears any two of the following <strong>conditions</strong> currently affecting an allied character in <strong>Range 5</strong>: <strong>Impaired</strong>, <strong>Jammed</strong>, <strong>Stunned</strong>, <strong>Slowed</strong>. That character may then either move up to their <strong>Speed</strong> or stand from <strong>Prone</strong>.",
-    "tags": [
-      {
-        "id": "tg_full_action"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 6
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_empowered_cloud_support",
-    "name": "EMPOWERED CLOUD",
-    "origin": {
-      "type": "Class",
-      "name": "SUPPORT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_empowered_cloud_support",
+        "name": "Empowered Cloud",
+        "origin": {
+            "type": "Class",
+            "name": "Support [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "When they start their turn adjacent to the Support, allied characters may clear one <strong>Condition</strong>. The Support takes <strong>4 Heat</strong> for each <strong>condition</strong> cleared this way.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "When they start their turn adjacent to the Support, allied characters may clear one <strong>Condition</strong>. The Support takes <strong>4 Heat</strong> for each <strong>condition</strong> cleared this way.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_latch_drone_support",
-    "name": "LATCH DRONE",
-    "origin": {
-      "type": "Class",
-      "name": "SUPPORT",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_latch_drone_support",
+        "name": "Latch Drone",
+        "origin": {
+            "type": "Class",
+            "name": "Support [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "System",
+        "effect": "Latch Drone (Size 1/2, HP {5/8/10}, Evasion {10/10/10}, E-Defense {10/10/10}, Tags: Drone)<br>This self-deploying drone clamps onto a character within <strong>Range 5</strong>, occupying the same space and moving with them. While the drone is attached, the target regains {5/8/10} HP at the start of each of their turns and gains <strong>+1 Accuracy</strong> on all checks, saves, and attacks. Enemies can target the drone with attacks. Only one <strong>Latch Drone</strong> can be deployed at a time, and if a new one is deployed, or the Support is destroyed, the old one disintegrates and is destroyed.",
+        "tags": [
+            {
+                "id": "tg_drone"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 6
+            },
+            {
+                "id": "tg_full_action"
+            }
+        ]
     },
-    "locked": false,
-    "type": "System",
-    "effect": "Latch Drone (Size 1/2, HP {5/8/10}, Evasion {10/10/10}, E-Defense {10/10/10}, Tags: Drone)<br>This self-deploying drone clamps onto a character within <strong>Range 5</strong>, occupying the same space and moving with them. While the drone is attached, the target regains {5/8/10} HP at the start of each of their turns and gains <strong>+1 Accuracy</strong> on all checks, saves, and attacks. Enemies can target the drone with attacks. Only one <strong>Latch Drone</strong> can be deployed at a time, and if a new one is deployed, or the Support is destroyed, the old one disintegrates and is destroyed.",
-    "tags": [
-      {
-        "id": "tg_drone"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 6
-      },
-      {
-        "id": "tg_full_action"
-      }
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_tear_down_witch",
-    "name": "TEAR DOWN",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_tear_down_witch",
+        "name": "Tear Down",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>{1/2/3} Heat</strong> immediately, and then a further <strong>4 Heat</strong> at the start of the Witch’s next turn; this effect does not stack. If an affected target or an adjacent hostile character takes the <strong>Stabilize</strong> action, they can choose to end the effect of this system in place of cooling their mech.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>{1/2/3} Heat</strong> immediately, and then a further <strong>4 Heat</strong> at the start of the Witch’s next turn; this effect does not stack. If an affected target or an adjacent hostile character takes the <strong>Stabilize</strong> action, they can choose to end the effect of this system in place of cooling their mech.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_blind_witch",
-    "name": "BLIND",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_blind_witch",
+        "name": "Blind",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>{2/3/4} Heat</strong> and must pass a <strong>Systems</strong> save or only be able to draw line of sight to adjacent spaces until the end of their next turn. If the target succeeds, they become <strong>Impaired</strong> until the end of their next turn instead.",
+        "tags": [
+            {
+                "id": "tg_full_tech"
+            }
+        ],
+        "tech_type": "Full",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>{2/3/4} Heat</strong> and must pass a <strong>Systems</strong> save or only be able to draw line of sight to adjacent spaces until the end of their next turn. If the target succeeds, they become <strong>Impaired</strong> until the end of their next turn instead.",
-    "tags": [
-      {
-        "id": "tg_full_tech"
-      }
-    ],
-    "tech_type": "Full",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_predatory_logic_witch",
-    "name": "PREDATORY LOGIC",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_predatory_logic_witch",
+        "name": "Predatory Logic",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Witch makes a tech attack against a hostile character within <strong>Sensors</strong>. On a success, the target immediately uses a <strong>non-Superheavy</strong> weapon chosen by the Witch to attack a character within <strong>Range</strong> also chosen by the Witch as a reaction. If the target takes the <strong>Brace</strong> reaction in response to this tech attack, they ignore the effect of this system; characters in the <strong>Danger Zone</strong> can't take the <strong>Brace</strong> reaction against this attack.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            },
+            {
+                "id": "tg_recharge",
+                "val": 6
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Witch makes a tech attack against a hostile character within <strong>Sensors</strong>. On a success, the target immediately uses a <strong>non-Superheavy</strong> weapon chosen by the Witch to attack a character within <strong>Range</strong> also chosen by the Witch as a reaction. If the target takes the <strong>Brace</strong> reaction in response to this tech attack, they ignore the effect of this system; characters in the <strong>Danger Zone</strong> can't take the <strong>Brace</strong> reaction against this attack.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      },
-      {
-        "id": "tg_recharge",
-        "val": 6
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_blur_witch",
-    "name": "BLUR",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": true
+    {
+        "id": "npc-rebake_npcf_blur_witch",
+        "name": "Blur",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": true
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The Witch counts as <strong>Invisible</strong> against characters in the <strong>Danger Zone</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The Witch counts as <strong>Invisible</strong> against characters in the <strong>Danger Zone</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_dark_cloud_witch",
-    "name": "DARK CLOUD",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_dark_cloud_witch",
+        "name": "Dark Cloud",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "The additional Heat dealt by <strong>Tear Down</strong> on the Witch’s next turn increases to <strong>7 Heat</strong> if the target is in the <strong>Danger Zone</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "The additional Heat dealt by <strong>Tear Down</strong> on the Witch’s next turn increases to <strong>7 Heat</strong> if the target is in the <strong>Danger Zone</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_chain_witch",
-    "name": "CHAIN",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_chain_witch",
+        "name": "Chain",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the Witch chains their target’s systems to a space within <strong>Range 3</strong> of the target. If the target moves more than <strong>3 spaces</strong> from that point (voluntarily or otherwise), they take <strong>{2/3/4} Heat</strong> and become <strong>Jammed</strong> until the end of their next turn, but the effect ends. Otherwise, they are chained until the Witch is destroyed or <strong>Stunned</strong>, or until the end of the scene.",
+        "tags": [
+            {
+                "id": "tg_quick_tech"
+            }
+        ],
+        "tech_type": "Quick",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the Witch chains their target’s systems to a space within <strong>Range 3</strong> of the target. If the target moves more than <strong>3 spaces</strong> from that point (voluntarily or otherwise), they take <strong>{2/3/4} Heat</strong> and become <strong>Jammed</strong> until the end of their next turn, but the effect ends. Otherwise, they are chained until the Witch is destroyed or <strong>Stunned</strong>, or until the end of the scene.",
-    "tags": [
-      {
-        "id": "tg_quick_tech"
-      }
-    ],
-    "tech_type": "Quick",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_petrify_witch",
-    "name": "PETRIFY",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_petrify_witch",
+        "name": "Petrify",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target becomes <strong>Slowed</strong> until the end of their next turn. When <strong>Slowed</strong> expires, they then become <strong>Immobilized</strong> until the end of their next turn. When <strong>Immobilized</strong> expires, they then become <strong>Stunned</strong> until the end of their next turn. Clearing any of these conditions (e.g. with <strong>Stabilize</strong>) prevents further conditions from occurring on subsequent turns.\n\nThis system can't be used again while it is currently in the process of affecting a character, and it can only be used 1/scene on each character.",
+        "tags": [
+            {
+                "id": "tg_full_tech"
+            }
+        ],
+        "tech_type": "Full",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ]
     },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target becomes <strong>Slowed</strong> until the end of their next turn. When <strong>Slowed</strong> expires, they then become <strong>Immobilized</strong> until the end of their next turn. When <strong>Immobilized</strong> expires, they then become <strong>Stunned</strong> until the end of their next turn. Clearing any of these conditions (e.g. with <strong>Stabilize</strong>) prevents further conditions from occurring on subsequent turns.\n\nThis system can't be used again while it is currently in the process of affecting a character, and it can only be used 1/scene on each character.",
-    "tags": [
-      {
-        "id": "tg_full_tech"
-      }
-    ],
-    "tech_type": "Full",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ]
-  },
-  {
-    "id": "npc-rebake_npcf_pain_transference_witch",
-    "name": "PAIN TRANSFERENCE",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": false
+    {
+        "id": "npc-rebake_npcf_pain_transference_witch",
+        "name": "Pain Transference",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Trait",
+        "effect": "Whenever a character takes additional Heat dealt by <strong>Tear Down</strong> on the Witch’s next turn, all other hostile characters within <strong>Range 3</strong> of that character also take the same amount of <strong>heat</strong>.",
+        "tags": []
     },
-    "locked": false,
-    "type": "Trait",
-    "effect": "Whenever a character takes additional Heat dealt by <strong>Tear Down</strong> on the Witch’s next turn, all other hostile characters within <strong>Range 3</strong> of that character also take the same amount of <strong>heat</strong>.",
-    "tags": []
-  },
-  {
-    "id": "npc-rebake_npcf_immolate_witch",
-    "name": "IMMOLATE",
-    "origin": {
-      "type": "Class",
-      "name": "WITCH",
-      "base": false
-    },
-    "locked": false,
-    "type": "Tech",
-    "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>burn</strong> equal to their current Heat. If the target is in the <strong>Danger Zone</strong>, all characters of the Witch's choice within a <strong>Burst 2</strong> area around the target must pass a <strong>Systems</strong> save or take half the amount of burn that the target takes. On a miss, the target takes <strong>2 Heat</strong> and becomes <strong>Impaired</strong> until the end of their next turn.",
-    "tags": [
-      {
-        "id": "tg_limited",
-        "val": 1
-      },
-      {
-        "id": "tg_full_tech"
-      }
-    ],
-    "tech_type": "Full",
-    "attack_bonus": [
-      2,
-      4,
-      6
-    ],
-    "accuracy": [
-      1,
-      1,
-      1
-    ]
-  }
+    {
+        "id": "npc-rebake_npcf_immolate_witch",
+        "name": "Immolate",
+        "origin": {
+            "type": "Class",
+            "name": "Witch [K]",
+            "base": false
+        },
+        "locked": false,
+        "type": "Tech",
+        "effect": "The Witch makes a tech attack against a character within <strong>Sensors</strong>. On a success, the target takes <strong>burn</strong> equal to their current Heat. If the target is in the <strong>Danger Zone</strong>, all characters of the Witch's choice within a <strong>Burst 2</strong> area around the target must pass a <strong>Systems</strong> save or take half the amount of burn that the target takes. On a miss, the target takes <strong>2 Heat</strong> and becomes <strong>Impaired</strong> until the end of their next turn.",
+        "tags": [
+            {
+                "id": "tg_limited",
+                "val": 1
+            },
+            {
+                "id": "tg_full_tech"
+            }
+        ],
+        "tech_type": "Full",
+        "attack_bonus": [
+            2,
+            4,
+            6
+        ],
+        "accuracy": [
+            1,
+            1,
+            1
+        ]
+    }
 ]


### PR DESCRIPTION
# Description

This PR decapitalizes all NPC Class and Feature names to enable more styling options for non-CompCon users of this data and better match the rebake PDFs. Attempt was made to catch exceptions to the rule (e.g. "SSC Total Suite" should not be "Ssc Total Suite") but I welcome a second set of eyes.

Also of note:
- I fixed the naming of Assault's "Fix and Flank" to match the rebake PDF. I left the ID alone as to not break anything, though.
- I appended ` [K]` to all Features' `origin.name` to ensure they get matched properly to their source.

## Issues Closed

Closes #26