### PR TITLE
fix(Veteran): fix Commando feature name typo

### DIFF
--- a/NPC Rebakes/npc_features.json
+++ b/NPC Rebakes/npc_features.json
@@ -6292,7 +6292,7 @@
   },
   {
     "id": "npc-rebake_npcf_commando_veteran",
-    "name": "Commando [Assualt]",
+    "name": "Commando [Assault]",
     "origin": {
       "type": "Template",
       "name": "Veteran [K]",


### PR DESCRIPTION
# Description

Fix a typo in the feature name for "Commando [Assault]".