### PR TITLE
Minor Fixes #9

### DIFF
--- a/NPC Rebakes/npc_features.json
+++ b/NPC Rebakes/npc_features.json
@@ -3731,7 +3731,7 @@
     },
     "locked": false,
     "type": "Reaction",
-    "effect": "The Pyro gains <strong>Resistance</strong> to all damage from the attack. The attacker must pass an <strong>Engineering</strong> save or take {3/4/5} <strong>Burn</strong>.",
+    "effect": "The Pyro gains <strong>Resistance</strong> to all damage from the attack. If the attack was a melee attack, the triggering character must pass an <strong>Engineering</strong> save or take {3/4/5} <strong>Burn</strong>.",
     "tags": [
       {
         "id": "tg_round",


### PR DESCRIPTION
# Description

A 9th round of data, typo, and description fixes.

## Type of Change
- Pyro's Superhot has a melee-only clause
![image](https://github.com/user-attachments/assets/8bf8aa74-b456-48dd-8965-14206a243222)

Delete irrelevant options.
- [ ] Bug fix (non-breaking change which fixes an issue)
