### PR TITLE
Removed Reflexive Blow 1/round limit.

### DIFF
--- a/NPC Rebakes/npc_features.json
+++ b/NPC Rebakes/npc_features.json
@@ -4785,10 +4785,6 @@
     "tags": [
       {
         "id": "tg_reaction"
-      },
-      {
-        "id": "tg_round",
-        "val": 1
       }
     ],
     "trigger": "Someone attacks the Sentinel’s ward."
@@ -7372,7 +7368,7 @@
         "id": "tg_reliable",
         "val": "{2/3/4}"
       },
-      { 
+      {
         "id": "tg_knockback",
         "val": "2"
       }


### PR DESCRIPTION
# Description

Fixes Reflexive Blow 1/round limit.

## Issue Number

Closes [#81](https://github.com/Shteb/Kais-NPC-Rebake-LCP/issues/81)

## Type of Change

Delete irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
