### PR TITLE
[FORMAT] Address Issue 90: Barricade Cube

### DIFF
--- a/Rebake Deployables/npc_features.json
+++ b/Rebake Deployables/npc_features.json
@@ -229,7 +229,7 @@
     },
     "locked": false,
     "type": "Trait",
-    "effect": "When a character moves adjacent to the Barricade Cube for the first time in a round, they must pass an Agility save or immediately take {2/3/4} AP Kinetic damage and lose all their remaining movement, as if they had become <strong>Engaged</strong>. On a success, they take the damage only.",
+    "effect": "When a character moves adjacent to the Barricade Cube for the first time in a round, they must pass an Agility save or immediately take <strong>{2/3/4} AP Kinetic damage</strong> and lose all their remaining movement, as if they had become <strong>Engaged</strong>. On a success, they take the damage only.",
     "tags": [],
     "hide_active": false
   },


### PR DESCRIPTION
# Description

Adds a missing Strong tag to the Spike Barrier damage entry.

## Issue Number

Closes #90 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

